### PR TITLE
only load configured auth strategies

### DIFF
--- a/lib/auth/strategy.js
+++ b/lib/auth/strategy.js
@@ -51,8 +51,19 @@ function AuthStrategy (app) {
   /**
    * Register Local Strategy
    */
+  passport.use(CreateLocalStrategy());
 
-  passport.use(new LocalStrategy(function(email, password, done) {
+  /**
+   * Register Facebook Strategy
+   */
+
+  if (app.get('config').auth.facebook) {
+    passport.use(CreateFacebookStrategy(Citizen));
+  }
+}
+
+function CreateLocalStrategy(Citizen) {
+  return new LocalStrategy(function(email, password, done) {
     Citizen.findByEmail(email, function(err, citizen) {
       if(err) return done(err);
 
@@ -60,40 +71,37 @@ function AuthStrategy (app) {
 
       return done(null, false, { message: 'Not found Citizen with email provided!' })
     });
-  }));
+  });
+}
 
-  /**
-   * Register Facebook Strategy
-   */
 
-  passport.use(new FacebookStrategy({
-        clientID: app.get('config').auth.facebook.clientID
-      , clientSecret: app.get('config').auth.facebook.clientSecret
-      , callbackURL: app.get('config').auth.facebook.callback
-    } , function(accessToken, refreshToken, profile, done) {
-      Citizen.findByProvider(profile, function(err, citizen) {
-        if (err) {
-          return done(err);
-        }
-
-        if(!citizen) {
-          citizen = new Citizen();
-        }
-
-        // refresh users profile data
-        citizen.firstName = profile.name.givenName;
-        citizen.lastName = profile.name.familyName;
-        citizen.email = profile.emails[0].value;
-        citizen.emails = profile.emails.map( function(email) { return email.value; } );
-        citizen.profiles.facebook = profile;
-        citizen.avatar = profile.imageUrl || 'http://gravatar.com/avatar/'.concat(utils.md5(citizen.email)).concat('?d=mm&size=200') || '';
-
-        citizen.save(function(err) {
-          console.log(citizen);
-          return done(null, citizen);
-        });
+function CreateFacebookStrategy(Citizen) {
+  return new FacebookStrategy({
+    clientID: app.get('config').auth.facebook.clientID
+    , clientSecret: app.get('config').auth.facebook.clientSecret
+    , callbackURL: app.get('config').auth.facebook.callback
+  } , function(accessToken, refreshToken, profile, done) {
+    Citizen.findByProvider(profile, function(err, citizen) {
+      if (err) {
+        return done(err);
       }
-    );
-  }));
 
+      if(!citizen) {
+        citizen = new Citizen();
+      }
+
+      // refresh users profile data
+      citizen.firstName = profile.name.givenName;
+      citizen.lastName = profile.name.familyName;
+      citizen.email = profile.emails[0].value;
+      citizen.emails = profile.emails.map( function(email) { return email.value; } );
+      citizen.profiles.facebook = profile;
+      citizen.avatar = profile.imageUrl || 'http://gravatar.com/avatar/'.concat(utils.md5(citizen.email)).concat('?d=mm&size=200') || '';
+
+      citizen.save(function(err) {
+        console.log(citizen);
+        return done(null, citizen);
+      });
+    });
+  });
 }


### PR DESCRIPTION
In the Partido De La Red session at TransparencyCamp just now I learned about the platform you are building.

The first thing I ran into when cloning and running locally was that removing Facebook from the config causes exception on start.

It should be possible to use only some auth providers. For testing, it's particularly convenient to have username/password and not need keys for social networks.

This is not quite ready to merge. It still shows the FB login in the top right corner. I'm not familiar enough with express or jade to know how to get information on configured strategies for making a conditional in the layout template.
With a little guidance on this, I'll finish up this PR.
