### PR TITLE
Overcomes local storage quota

### DIFF
--- a/lib/store/local.js
+++ b/lib/store/local.js
@@ -35,6 +35,13 @@ LocalStore.prototype.get = function(key) {
 }
 
 LocalStore.prototype.set = function(key, value) {
+  var storageTest = 'foo';
+  try {
+    storage.setItem(storageTest, storageTest);
+    storage.removeItem(storageTest);
+  } catch(e) {
+    return this;
+  }
   return storage.setItem(key, serialize(value)), this;
 }
 


### PR DESCRIPTION
Fixes #296

PoC:

![screen shot 2014-03-12 at 5 50 00 pm](https://f.cloud.github.com/assets/705860/2404722/48c13e00-aa41-11e3-862f-7b623eb7eadb.png)

As you can see, the first two windows show iPhone sessions that reached the localStorage quota (localStore is empty), the staging instance (2nd window, with applied patch) doesn't throw the error.

Code borrowed from https://github.com/Modernizr/Modernizr/blob/master/feature-detects/storage/localstorage.js
