### PR TITLE
[boot] - Fix signup form ui bug in firefox.

### DIFF
--- a/lib/boot/boot.styl
+++ b/lib/boot/boot.styl
@@ -131,7 +131,6 @@ section.site-content
   form
     label
       display:inline-block
-      float:left
     .forgot
       float:right
       a


### PR DESCRIPTION
Fix float elements from this:

![screen2](https://cloud.githubusercontent.com/assets/796960/3430130/091bf1f0-005e-11e4-9727-17104d873561.png)

To this:
![screen1](https://cloud.githubusercontent.com/assets/796960/3430128/022ef1f8-005e-11e4-82b9-0537f300b09a.png)
