### PR TITLE
On creating a law, routes to the page for the new law. Closes #421

### DIFF
--- a/lib/admin-laws-form/view.js
+++ b/lib/admin-laws-form/view.js
@@ -28,6 +28,7 @@ module.exports = LawForm;
 /**
  * Creates a password edit view
  */
+var created = false;
 
 function LawForm(law) {
   if (!(this instanceof LawForm)) {
@@ -36,11 +37,12 @@ function LawForm(law) {
 
   this.setLocals(law);
 
-  // this.formsubmit = this.formsubmit.bind(this);
-  // this.onsuccess = this.onsuccess.bind(this);
-
   FormView.call(this, template, this.locals);
   this.renderDateTimePickers();
+  if (created) {
+    this.messages([t('admin-laws-form.message.onsuccess')]);
+    created = false;
+  }
 }
 
 /**
@@ -111,9 +113,14 @@ LawForm.prototype.switchOff = function() {
  * @api private
  */
 
-LawForm.prototype.onsuccess = function() {
-  log('Law create successful');
+LawForm.prototype.onsuccess = function(response) {
+  log('Law successfully saved');
+  if (response.req.url.match(/.*create.*/)) {
+    created = true;
+    page('/admin/laws/' + response.body.id);
+  }
   this.messages([t('admin-laws-form.message.onsuccess')]);
+  $("#content").animate({ scrollTop: 0 }, "fast");
 }
 
 /**


### PR DESCRIPTION
This should fix the problem of not showing the Publish link. Also, it solves the other problems I mentioned before:
- Allows you to create clauses and links
- Saving changes now works without having to reload in the browser

There are some other things to consider, and if you don't like them, you are free to ask me to change them:
1. I added a call to scroll to the top after saving. 
   I think that will make it clearer to the user that their work was saved (before, I couldn't see the "saved successfully" message).
2. I'd never worked with Page.js before this project, which is why I'd asked if we should just redirect. The problem was solved by simply using the page() method. 
   HOWEVER, there was still a problem in that I couldn't get the "saved successfully" message to show up after a creation (because the page call generates a new LawForm, which the onsuccess handler can't reach). I solved the problem using the hack of a global variable, since I couldn't see a way to pass the information on the context without actually changing the URL. Is there a better way? What would you recommend?
