### PR TITLE
New API method for getting the version info. Closes #444

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,0 +1,28 @@
+/**
+ * Module dependencies.
+ */
+
+var express = require('express');
+var api = require('lib/db-api');
+var utils = require('lib/utils');
+var accepts = require('lib/accepts');
+var restrict = utils.restrict;
+var staff = utils.staff;
+var pluck = utils.pluck;
+var expose = utils.expose;
+var log = require('debug')('democracyos:law');
+var package = require('../../package');
+
+var app = module.exports = express();
+
+/**
+ * Limit request to json format only
+ */
+
+app.use(accepts(['application/json', 'text/html']));
+
+app.get('/', function (req, res) {
+    res.json({app: 'democracyos', env: process.env.NODE_ENV, version: package.version, apiUrl: '/api'});
+});
+
+

--- a/lib/boot/index.js
+++ b/lib/boot/index.js
@@ -102,6 +102,12 @@ app.use('/rss', require('lib/rss'));
 app.use(require('lib/store'));
 
 /**
+ * Root API Service
+ */
+
+app.use('/api', require('lib/api'));
+
+/**
  * Tag API Service
  */
 


### PR DESCRIPTION
I took the approach of putting the method at `/api/`, and making it browser-viewable. If you'd rather have it at root, json-only, let me know and I'll change it.
