### PR TITLE
[model:law] Safer way to store votes. Related to #394.

### DIFF
--- a/lib/models/law.js
+++ b/lib/models/law.js
@@ -299,10 +299,10 @@ LawSchema.methods.vote = function(citizen, value, cb) {
   // Here we could provide a 5000ms tolerance (5s)
   // or something... to prevent false positives
   if (this.closingAt && (+new Date(this.closingAt) < +new Date) ) return cb(new Error('Can\'t vote after closing date.'));
-  
+
   var vote = { author: citizen, value: value, caster: citizen };
   this.unvote(citizen);
-  this.votes.push(vote);
+  this.votes.addToSet(vote);
   // Add citizen as participant
   this.addParticipant(citizen);
   this.save(cb);
@@ -346,7 +346,7 @@ LawSchema.methods.unvote = function(citizen, cb) {
     log('Remove vote %j', removed);
   });
 
-  if (cb) this.save(cb);
+  if (votes.length) this.save(cb);
 };
 
 /**


### PR DESCRIPTION
On the `vote` method I replaced `MongooseArray#push` call by [`MongooseArray#addToSet`](http://mongoosejs.com/docs/api.html#types_array_MongooseArray-addToSet), which avoids duplicates.
Also, I've found a weird thing related to the call to `unvote`. The `this.save(cb)` method was never been called because `cb` is always `undefined`. I replaced the condition by `votes.length`, that seems more proper. I've tested it and it made no difference.
I couldn't reproduce the case that generates the error, it's still under analysis.
Also, we need to write a migration script in order to remove n-plicated votes on existing databases.
