### PR TITLE
Revert "[model:law] Safer way to store votes. Related to #394."

### DIFF
--- a/lib/models/law.js
+++ b/lib/models/law.js
@@ -299,10 +299,10 @@ LawSchema.methods.vote = function(citizen, value, cb) {
   // Here we could provide a 5000ms tolerance (5s)
   // or something... to prevent false positives
   if (this.closingAt && (+new Date(this.closingAt) < +new Date) ) return cb(new Error('Can\'t vote after closing date.'));
-
+  
   var vote = { author: citizen, value: value, caster: citizen };
   this.unvote(citizen);
-  this.votes.addToSet(vote);
+  this.votes.push(vote);
   // Add citizen as participant
   this.addParticipant(citizen);
   this.save(cb);
@@ -346,7 +346,7 @@ LawSchema.methods.unvote = function(citizen, cb) {
     log('Remove vote %j', removed);
   });
 
-  if (votes.length) this.save(cb);
+  if (cb) this.save(cb);
 };
 
 /**


### PR DESCRIPTION
Reverts DemocracyOS/app#487

This isn't working properly and does not produce the desired effect.
- Mongoose's `addToSet` is only appropriate for native types, since it relies on the built-in identity comparator (`===`). It's no good for complex objects.
- the `unvote` method is not being used properly, since no callback is being passed.
- the `if (cb) this.save(cb)` line is adequate but not working because of my former point.
