### PR TITLE
[view] - Fix Upvote comment button underlines on hover

### DIFF
--- a/lib/comments-view/comments-view.styl
+++ b/lib/comments-view/comments-view.styl
@@ -153,8 +153,7 @@ content_width = 580px
             font-weight bold
             font-size 20px
             margin-right 10px
-        &:hover
-          text-decoration none
+        text-decoration none
         &.link-report,
         &.link-remove,
         &.link-edit


### PR DESCRIPTION
I've applied the fix for the comment-action class since it's also happening for the "reply to argument" button.

Closes #516.
