### PR TITLE
Only give user the votes they casted - closes #1145

### DIFF
--- a/lib/proposal-options/proposal-options.js
+++ b/lib/proposal-options/proposal-options.js
@@ -126,12 +126,9 @@ export default class ProposalOptions extends View {
 
     var cast = this.find('.votes-cast em');
 
-    var upvotes = this.proposal.upvotes || [];
-    var downvotes = this.proposal.downvotes || [];
-    var abstentions = this.proposal.abstentions || [];
-    var census = abstentions.concat(downvotes).concat(upvotes) || [];
+    var census = (this.proposal.voted) ? this.proposal.census : this.proposal.census + 1;
 
-    cast.html(t(t('proposal-options.votes-cast', { num: census.length || "0" })));
+    cast.html(t(t('proposal-options.votes-cast', { num: census })));
     this.track('vote topic');
   }
 
@@ -186,12 +183,12 @@ export default class ProposalOptions extends View {
     let upvotes = this.proposal.upvotes || [];
     let downvotes = this.proposal.downvotes || [];
     let abstentions = this.proposal.abstentions || [];
-    let census = abstentions.concat(downvotes).concat(upvotes);
+    let census = this.proposal.census;
     let data = [];
 
     if (!container.length) return;
 
-    if (census.length) {
+    if (census) {
       data.push({
         value: upvotes.length,
         color: "#a4cb53",

--- a/lib/proposal-options/template.jade
+++ b/lib/proposal-options/template.jade
@@ -1,12 +1,12 @@
 - var positives = proposal.upvotes || []
 - var negatives = proposal.downvotes || []
 - var neutrals = proposal.abstentions || []
-- var census = neutrals.concat(negatives).concat(positives) || []
+- var census = proposal.census
 
 - var participants = proposal.participants || []
 
 - var closed = proposal.closingAt && +new Date(proposal.closingAt) < Date.now()
-- var voted = user && ~census.indexOf(user.id)
+- var voted = user && proposal.voted
 
 .inner-container.commentable-container(class=proposal.votable ? '' : 'hide')
 
@@ -46,18 +46,18 @@
             = '.'
 
       .votes-cast
-        em.text-muted= t('proposal-options.votes-cast', { num: census.length || "0" })
+        em.text-muted= t('proposal-options.votes-cast', { num: census })
 
     - if (closed)
       .results-box.row.clearfix
-        p.alert.alert-info(class=census.length ? 'hide' : ''): label= t('proposal-options.no-votes-cast')
-        .results-chart(class= census.length ? '' : 'hide').col-sm-6
+        p.alert.alert-info(class=census ? 'hide' : ''): label= t('proposal-options.no-votes-cast')
+        .results-chart(class= census ? '' : 'hide').col-sm-6
           canvas#results-chart(width="220", height="220")
-        .results-summary(class= census.length ? '' : 'hide').col-sm-6
+        .results-summary(class= census ? '' : 'hide').col-sm-6
           - if (positives.length)
             .votes-afirmative.votes-results
               h5= t('proposal-options.yea')
-              - var width = census.length ? (positives.length/census.length)*100 : 0;
+              - var width = census ? (positives.length/census)*100 : 0;
               - var width = Math.round(width*100)/100
               - var s = 1 === positives.length ? '' : 's'
               span.percent #{width} %
@@ -66,7 +66,7 @@
           - if (negatives.length)
             .votes-negative.votes-results
               h5= t('proposal-options.nay')
-              - var width = census.length ? (negatives.length/census.length)*100 : 0;
+              - var width = census ? (negatives.length/census)*100 : 0;
               - var width = Math.round(width*100)/100
               - var s = 1 === negatives.length ? '' : 's'
                 span.percent #{width} %
@@ -75,7 +75,7 @@
           - if (neutrals.length)
             .votes-neutral.votes-results
               h5= t('proposal-options.abstain')
-              - var width = census.length ? (neutrals.length/census.length)*100 : 0;
+              - var width = census ? (neutrals.length/census)*100 : 0;
               - var width = Math.round(width*100)/100
               - var s = 1 === neutrals.length ? '' : 's'
                 span.percent #{width} %

--- a/lib/topic-api/index.js
+++ b/lib/topic-api/index.js
@@ -33,13 +33,22 @@ var topicListKeys = [
 
 var topicKeys = topicListKeys
               + ' '
-              + 'summary clauses source state upvotes downvotes abstentions';
+              + 'summary clauses source state upvotes downvotes abstentions census';
 
 function exposeTopic(topicDoc, user, keys) {
   if (!keys) keys = topicKeys;
 
   var topic = topicDoc.toJSON();
   topic.voted = topicDoc.votedBy(user);
+
+  topic.census = topic.abstentions.length + topic.upvotes.length + topic.downvotes.length;
+
+  var removeForbidden = (author) => (user && author == user.id);
+  var hideForbidden = (author) => (user && author == user.id) ? author : 'hidden';
+
+  ['abstentions', 'upvotes', 'downvotes'].forEach(value => {
+    topic[value] = (topic.open) ? topic[value].filter(removeForbidden) : topic[value].map(hideForbidden);
+  });
 
   return expose(keys)(topic);
 }


### PR DESCRIPTION
If a topic is open, the server sends only the user's vote and the census, which is now calculated on the server side.

If the topic is closed, the server sends the user's vote and the upvote, downvote, abstention arrays with "hidden" for all UserIds that are not the current logged in User.

I tested it with open topics, closed topics, and it works as described. Votes cast is properly updated, the chart renders correctly, etc.