### PR TITLE
Adding forum-reserved-names.js

### DIFF
--- a/bin/dos-db
+++ b/bin/dos-db
@@ -134,7 +134,7 @@ function connect (fn) {
  */
 function models(fn) {
   write("Register mongoose models.");
-  var except = ['index.js'];
+  var except = ['index.js', 'forum-reserved-names.js'];
   var files = dir(resolve('./lib/models/'));
   files && files.forEach(function(f) {
     if (~except.indexOf(f)) return;


### PR DESCRIPTION
[`models`](https://github.com/DemocracyOS/democracyos/blob/master/bin/dos-db#L135) tries to import [`./lib/models/forum-reserved-names.js`](https://github.com/DemocracyOS/democracyos/blob/master/lib/models/forum-reserved-names.js) and treat it as a function. This doesn't work.

This adds `forum-reserved-names-.js` to the [list of exceptions to skip](https://github.com/DemocracyOS/democracyos/blob/master/bin/dos-db#L137).

Fixes #1171.