### PR TITLE
Replace broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 DemocracyOS is an online space for deliberation and voting on political proposals. It is a platform for a more open and participatory government.The software aims to stimulate better arguments and come to better rulings, as peers.
 
-Check out the [live DemocracyOS demo](http://demo.democracyos.org).
+Check out the [live DemocracyOS demo](https://app.democracyos.org/).
 
 ![DemocracyOS](https://cldup.com/5UCVpUnOhO.png)
 


### PR DESCRIPTION
The live demo was pointing to a broken link, now points to https://app.democracyos.org/