### PR TITLE
Add absolute paths

### DIFF
--- a/docker/development.Dockerfile
+++ b/docker/development.Dockerfile
@@ -11,6 +11,8 @@ WORKDIR /usr/src
 
 RUN npm install --quiet --unsafe-perm
 
+ENV NODE_PATH=.
+
 EXPOSE 3000
 
 CMD ["./node_modules/.bin/gulp", "bws"]

--- a/lib/site/header/component.js
+++ b/lib/site/header/component.js
@@ -1,8 +1,8 @@
-import React, {Component} from 'react'
-import user from '../../user/user'
-import config from '../../config/config'
-import UserBadge from './user-badge/component.js'
-import AnonUser from './anon-user/component.js'
+import React, { Component } from 'react'
+import user from 'lib/user/user'
+import config from 'lib/config/config'
+import UserBadge from './user-badge/component'
+import AnonUser from './anon-user/component'
 
 export default class Header extends Component {
   constructor (props) {

--- a/lib/site/header/header.js
+++ b/lib/site/header/header.js
@@ -1,6 +1,6 @@
-import Header from './component'
 import React from 'react'
-import {render} from 'react-dom'
+import { render } from 'react-dom'
+import Header from './component'
 
 render(
   <Header />,

--- a/package.json
+++ b/package.json
@@ -189,9 +189,9 @@
   },
   "scripts": {
     "start": "NODE_PATH=. node index.js",
-    "build": "gulp build",
-    "watch": "gulp watch",
-    "clean": "gulp clean",
+    "build": "NODE_PATH=. gulp build",
+    "watch": "NODE_PATH=. gulp watch",
+    "clean": "NODE_PATH=. gulp clean",
     "heroku-postbuild": "gulp build --minify",
     "test": "NODE_PATH=. MONGO_URL=mongodb://localhost/DemocracyOS-test gulp test"
   }


### PR DESCRIPTION
After this pull is merged, the imports to another components on front-end should be done using absolute paths from `/lib`.

Before:
```
import user from '../user/user'
```
After:
```
import user from 'lib/user/user'
```