### PR TITLE
Add insecure warning to pages

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,6 +1,7 @@
 {
   "locale": "en",
   "protocol": "http",
+  "warnHTTP": true,
   "host": "localhost",
   "publicPort": 3000,
   "mongoUrl": "mongodb://localhost/DemocracyOS-dev",
@@ -79,7 +80,8 @@
     "tweetText",
     "segmentKey",
     "spamLimit",
-    "availableLocales"
+    "availableLocales",
+    "warnHTTP"
   ],
   "socialshare": {
     "siteName": "DemocracyOS",

--- a/lib/header/styles.styl
+++ b/lib/header/styles.styl
@@ -28,13 +28,22 @@ header.app-header
   top 0
   left 0
   right 0
-  height header_height
   background #64476e
   color white
-  padding-left spacing
   font-weight bold
   text-transform uppercase
   font-size 12px
+
+  #header-container
+    height header_height
+    padding-left spacing
+
+  .ssl-warning
+    padding spacing
+    background-color #c0392b
+    width 100%
+    position fixed
+    bottom 0
 
   &.with-contrast
     box-shadow 0 2px 2px #d5d5d5

--- a/lib/header/template.jade
+++ b/lib/header/template.jade
@@ -27,3 +27,6 @@
     - var target = config.homeLink ? {} : { 'target': '_blank'};
     a.login.pull-left(href=config.organizationUrl, style=style)&attributes(target)
       span= config.organizationName
+
+.ssl-warning.hide
+  a(href='//docs.democracyos.org/configuration.html#ssl')= t('header.insecure-warning')

--- a/lib/header/view.js
+++ b/lib/header/view.js
@@ -16,6 +16,10 @@ export default class HeaderView extends View {
     super(template)
     this.build()
     this.user = this.el.find('.user')
+
+    if (config.warnHTTP && location.hostname != 'localhost' && location.href.split('://')[0] != 'https') {
+      this.el.find('.ssl-warning').removeClass('hide')
+    }
   }
 
   switchOn () {

--- a/lib/translations/lib/en.json
+++ b/lib/translations/lib/en.json
@@ -199,6 +199,7 @@
   "header.settings": "Settings",
   "header.signin": "Login",
   "header.signup": "Signup",
+  "header.insecure-warning": "Warning: You are using an insecure version of democracyos. See the docs for details on implementing SSL.",
   "help.faq.title": "FAQ",
   "help.glossary.title": "Glossary",
   "help.markdown.title": "Formatting help",


### PR DESCRIPTION
Addresses #1285, adds a bar at the bottom that warns if it isn't local or being served over https.

![screenshot 2016-09-17 15 50 29](https://cloud.githubusercontent.com/assets/3477162/18611459/ae5b1466-7cee-11e6-9200-7b98883c11f1.png)
