### PR TITLE
update various package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "democracyos",
-  "version": "1.4.2",
+  "version": "1.4.4",
   "description": "An online space for deliberation and voting on political proposals. The software aims to stimulate better arguments and come to better rulings.",
   "homepage": "http://www.democracyos.org/",
   "keywords": [
@@ -63,13 +63,13 @@
     "bean": "^1.0.15",
     "bowser": "0.7.2",
     "brfs": "1.4.0",
-    "browserify": "^9.0.8",
+    "browserify": "^13.1.0",
     "bus": "0.1.0",
     "change-case": "^2.3.0",
     "chart.js": "1.0.2",
     "co-prompt": "~1.0.0",
     "commander": "~2.0.0",
-    "component": "1.0.0",
+    "component": "^1.1.0",
     "component-closest": "0.1.4",
     "component-cookie": "^1.1.1",
     "component-dom": "1.0.8",
@@ -83,7 +83,7 @@
     "democracyos-aurora-popover": "0.0.1",
     "democracyos-aurora-tip": "^1.0.0",
     "democracyos-calendar": "^1.0.3",
-    "democracyos-config": "^1.0.0",
+    "democracyos-config": "^1.1.0",
     "democracyos-confirmation": "^0.0.5",
     "democracyos-datepicker": "^1.0.3",
     "democracyos-db": "0.0.1",
@@ -92,7 +92,7 @@
     "democracyos-headroom.js": "^0.7.0",
     "democracyos-list.js": "^1.1.4",
     "democracyos-loading-lock": "^0.1.0",
-    "democracyos-notifier": "^1.0.1",
+    "democracyos-notifier": "1.0.1",
     "democracyos-quill": "^0.19.12",
     "democracyos-side-comments": "~0.0.20",
     "democracyos-snap.js": "^2.0.0",
@@ -111,16 +111,17 @@
     "get-form-data": "1.2.2",
     "gulp": "^3.9.1",
     "gulp-add-src": "0.2.0",
+    "gulp-clean-css": "^2.0",
     "gulp-concat-css": "2.2.0",
     "gulp-if": "1.2.5",
-    "gulp-minify-css": "1.1.0",
+ 
     "gulp-sourcemaps": "^1.5.2",
     "gulp-stylint": "1.1.2",
     "gulp-stylus": "2.5.0",
     "gulp-util": "3.0.4",
     "http-auth": "1.3.0",
     "inserted": "0.0.4",
-    "jade": "^1.11.0",
+
     "jadeify": "^4.2.0",
     "jsdom": "6.3.0",
     "jwt-simple": "0.2.0",
@@ -129,9 +130,10 @@
     "markdownify": "0.1.0",
     "marked": "^0.3.5",
     "merge": "^1.2.0",
+    "minimatch": "^3.0.3",
     "mkdirp": "^0.5.0",
     "moment": "2.9.0",
-    "mongoose": "3.8.24",
+    "mongoose": "^4.6.0",
     "mongoose-gravatar": "0.3.0",
     "mongoose-validators": "^0.1.0",
     "mongoose-voting": "0.1.1",
@@ -146,6 +148,7 @@
     "passport-facebook": "2.0.x",
     "passport-local": "~0.1.6",
     "passport-local-mongoose": "~0.2.4",
+    "pug": "2.0.0-beta6",
     "qs": "2.4.1",
     "removed": "0.0.5",
     "store": "1.3.17",
@@ -166,7 +169,7 @@
     "vinyl-source-stream": "^1.1.0",
     "watchify": "~3.7.0",
     "xss": "0.2.2",
-    "yargs": "3.9.1"
+    "yargs": "5.0.0"
   },
   "devDependencies": {
     "arr-diff": "^1.0.1",
@@ -180,8 +183,8 @@
   },
   "main": "pdr",
   "engines": {
-    "node": "4.0.0",
-    "npm": "2.14.2"
+    "node": "6.6.0",
+    "npm": "3.10.3"
   },
   "scripts": {
     "start": "NODE_PATH=. node index.js",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "gulp-util": "3.0.4",
     "http-auth": "1.3.0",
     "inserted": "0.0.4",
-
     "jadeify": "^4.2.0",
     "jsdom": "6.3.0",
     "jwt-simple": "0.2.0",
@@ -130,7 +129,6 @@
     "markdownify": "0.1.0",
     "marked": "^0.3.5",
     "merge": "^1.2.0",
-    "minimatch": "^3.0.3",
     "mkdirp": "^0.5.0",
     "moment": "2.9.0",
     "mongoose": "^4.6.0",
@@ -169,7 +167,7 @@
     "vinyl-source-stream": "^1.1.0",
     "watchify": "~3.7.0",
     "xss": "0.2.2",
-    "yargs": "5.0.0"
+    "yargs": "^5.0.0"
   },
   "devDependencies": {
     "arr-diff": "^1.0.1",


### PR DESCRIPTION
democracyOS builds and runs fine on Linux with these updated packages, node 6.6.0 and npm 3.10.3
