### PR TITLE
#1332 Realigned input fields in 'new topic' form 

### DIFF
--- a/lib/admin/admin-topics-form/styles.styl
+++ b/lib/admin/admin-topics-form/styles.styl
@@ -39,13 +39,11 @@
         overflow hidden
 
         .input-group
-          width 40%
-          width unquote("calc(50% - 6px)")
-          float left
+          margin-bottom inherit
           margin-left 0
 
           &:last-child
-            margin-left 12px
+            width unquote("calc(50% - 6px)")
 
         span.error
           top 10px


### PR DESCRIPTION
Realigned date and time input fields with the label
from this

![misaligned form screenshot](https://cloud.githubusercontent.com/assets/5219738/20244532/2d58108a-a98f-11e6-817e-91319f3f21de.png)

to 

![fixed screenshot](https://cloud.githubusercontent.com/assets/5219738/20244531/1be5105a-a98f-11e6-98bf-ec6395ea61d7.png)

 by adjusting the jade style sheet.
