### PR TITLE
Add link attributes to generated text html output

### DIFF
--- a/lib/admin/admin-topics-form/view.js
+++ b/lib/admin/admin-topics-form/view.js
@@ -31,7 +31,7 @@ export default class TopicForm extends FormView {
     if (topic) {
       action = '/api/topic/' + topic.id
       title = 'admin-topics-form.title.edit'
-      topic.body = serializer.toHTML(topic.clauses)
+      topic.body = serializer.toHTML(topic.clauses).replace(/<a/g, '<a rel="noopener noreferer" target="_blank"')
     } else {
       action = '/api/topic/create'
       title = 'admin-topics-form.title.create'

--- a/lib/site/topic-layout/topic-article/comments/parse-comment.js
+++ b/lib/site/topic-layout/topic-article/comments/parse-comment.js
@@ -6,6 +6,10 @@ renderer.heading = function (text, level) {
   return `<h${level}>${text}</h${level}>`
 }
 
+renderer.link = function (href, title, text) {
+  return `<a href="${href}" title="${title}" rel="noopener noreferer" target="_blank">${text}</a>`
+}
+
 export default function parseComment (comment) {
   return new Promise((resolve, reject) => {
     if (!comment.text) return resolve(comment)


### PR DESCRIPTION
Add `rel="noopener noreferer" target="_blank"` to markdown text inputs.