### PR TITLE
add a `make package` install step

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -36,6 +36,7 @@ To run it on **Windows** you must use [Docker](https://www.docker.io/). In the [
 - [Fork](http://help.github.com/articles/fork-a-repo) or download this repository.
 - `cd` to the project's location
 - Make sure MongoDB is running and reachable as configured in `config/development.json`. (Default values should work)
+- Run `make packages`
 - Set up your [configuration](configuration.md), and add your email as [staff](configuration.md#-staff-) to be able to initialize your app.
 - Run `make`
 - Boom! DemocracyOS should be running on port 3000.


### PR DESCRIPTION
Since the next step is about setting up the configuration file, and the [configuration guide](https://github.com/DemocracyOS/democracyos/blob/master/docs/configuration.md) states that :

> You can generate configuration files using the command:
>
>```
>NODE_ENV=development node ./bin/dos-install --config
>```

The dependencies are then required before to configure. Without it, generating a configuration file leads to : 

```
$ NODE_ENV=development node ./bin/dos-install --config
module.js:472
    throw err;
    ^

Error: Cannot find module 'commander'
```