### PR TITLE
[v3] Add Reaction Instance API, DB-API and Tests

### DIFF
--- a/main/api.js
+++ b/main/api.js
@@ -18,6 +18,7 @@ router.use(
 router.use('/users', require('../users/api/users'))
 router.use('/settings', require('../cms/api/settings'))
 router.use('/reaction-rule', require('../reactions/api/reaction-rule'))
+router.use('/reaction-instance', require('../reactions/api/reaction-instance'))
 router.use('/posts', require('../cms/api/posts'))
 
 // Catch 404 and forward to error handler.

--- a/main/config.js
+++ b/main/config.js
@@ -52,7 +52,7 @@ const CONFIG = {
 //  CONFIG VALIDATION
 // ==============================================================================
 
-if (process.env.NODE_ENV === 'test' && !CONFIG.MONGO_URL) {
+if (process.env.NODE_ENV === 'test') {
   CONFIG.MONGO_URL = 'mongodb://localhost/DemocracyOS-test'
 }
 

--- a/main/mongoose.js
+++ b/main/mongoose.js
@@ -19,6 +19,7 @@ require('../users/models/user')
 require('../cms/models/setting')
 require('../cms/models/post')
 require('../reactions/models/reaction-rule')
+require('../reactions/models/reaction-instance')
 
 // handle errors
 const db = mongoose.connection

--- a/reactions/api/reaction-instance.js
+++ b/reactions/api/reaction-instance.js
@@ -1,0 +1,69 @@
+const express = require('express')
+const {
+  OK,
+  CREATED,
+  NO_CONTENT
+} = require('http-status')
+const ReactionInstance = require('../db-api/reaction-instance')
+// Requires winston lib for log
+const { log } = require('../../main/logger')
+// Requires CRUD apis
+const router = express.Router()
+
+router.route('/')
+  // POST route
+  .post(async (req, res, next) => {
+    try {
+      const newReactionInstance = await ReactionInstance.create(req.body)
+      res.status(CREATED).json({
+        data: newReactionInstance
+      })
+    } catch (err) {
+      next(err)
+    }
+  })
+  // GET reaction-instances
+  .get(async (req, res, next) => {
+    try {
+      const results = await ReactionInstance.list({ limit: req.query.limit, page: req.query.page })
+
+      res.status(OK).json({
+        results: results.docs,
+        pagination: {
+          count: results.total,
+          page: results.page,
+          limit: results.limit
+        }
+      })
+    } catch (err) {
+      next(err)
+    }
+  })
+
+router.route('/:id')
+  .get(async (req, res, next) => {
+    try {
+      const user = await ReactionInstance.get(req.params.id)
+      res.status(OK).json(user)
+    } catch (err) {
+      next(err)
+    }
+  })
+  .put(async (req, res, next) => {
+    try {
+      const updatedReactionInstance = await ReactionInstance.update({ id: req.params.id, reactionInstance: req.body })
+      res.status(OK).json(updatedReactionInstance)
+    } catch (err) {
+      next(err)
+    }
+  })
+  .delete(async (req, res, next) => {
+    try {
+      await ReactionInstance.remove(req.params.id)
+      res.status(NO_CONTENT).json(req.params.id)
+    } catch (err) {
+      next(err)
+    }
+  })
+
+module.exports = router

--- a/test/reactions/api/reaction-instance.js
+++ b/test/reactions/api/reaction-instance.js
@@ -1,21 +1,124 @@
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+const {
+  OK,
+  CREATED,
+  NO_CONTENT
+} = require('http-status')
+const ReactionInstance = require('../../../reactions/models/reaction-instance')
+const ReactionRule = require('../../../reactions/models/reaction-rule')
+const sampleReactionRule = new ReactionRule({
+  method: 'LIKE',
+  startingDate: new Date('2017-12-20 00:00:00'),
+  closingDate: new Date('2018-02-20 00:00:00')
+})
+const sampleReactionInstance = {
+  reactionId: sampleReactionRule._id,
+  resourceType: 'Article',
+  resourceId: '000001',
+  results: []
+}
+
+const anotherReactionRule = new ReactionRule({
+  method: 'LIKE',
+  startingDate: new Date('2017-12-24 00:00:00'),
+  closingDate: new Date('2018-02-25 00:00:00')
+})
+const anotherReactionInstance = {
+  reactionId: anotherReactionRule._id,
+  resourceType: 'Video',
+  resourceId: '000002',
+  results: []
+}
+
+const otherReactionRule = new ReactionRule({
+  method: 'LIKE',
+  startingDate: new Date('2017-12-23 00:00:00'),
+  closingDate: new Date('2018-02-28 00:00:00')
+})
+const otherReactionInstance = {
+  reactionId: otherReactionRule._id,
+  resourceType: 'Post',
+  resourceId: '000003',
+  results: []
+}
+
+const expect = chai.expect
+chai.use(chaiHttp)
+
 describe('/api/v1.0/reaction-instance', () => {
+  before(async () => {
+    await require('../../../main')
+  })
+
+  beforeEach(async () => {
+    await ReactionInstance.remove({})
+  })
+
   describe('#post', () => {
-    it('should create a user')
+    it('should create a reaction instance', async () => {
+      const res = await chai.request('http://localhost:3000')
+        .post('/api/v1.0/reaction-instance')
+        .send(sampleReactionInstance)
+
+      expect(res).to.have.status(CREATED)
+    })
   })
 
   describe('#list', () => {
-    it('should list all users')
+    it('should list all reaction instances', async () => {
+      await (new ReactionInstance(sampleReactionInstance)).save()
+      await (new ReactionInstance(anotherReactionInstance)).save()
+      await (new ReactionInstance(otherReactionInstance)).save()
+
+      const res = await chai.request('http://localhost:3000')
+        .get('/api/v1.0/reaction-instance')
+        .query({ limit: 10, page: 1 })
+
+      expect(res).to.have.status(OK)
+
+      const { results, pagination } = res.body
+
+      expect(results).to.be.a('array')
+      expect(results.length).to.be.eql(3)
+      expect(pagination).to.have.property('count')
+      expect(pagination).to.have.property('page')
+      expect(pagination).to.have.property('limit')
+    })
   })
 
   describe('#get', () => {
-    it('should get a user by id')
+    it('should get a reaction instance by id', async () => {
+      let newReactionInstance = await (new ReactionInstance(sampleReactionInstance)).save()
+      const res = await chai.request('http://localhost:3000')
+        .get(`/api/v1.0/reaction-instance/${newReactionInstance.id}`)
+
+      expect(res).to.have.status(OK)
+      expect(res.body).to.be.a('object')
+      // Check if the response contains all the properties of the object
+      let properties = Object.keys(sampleReactionInstance)
+      properties.map((prop) => expect(res.body).to.have.property(prop))
+    })
   })
 
   describe('#put', () => {
-    it('should update a user')
+    it('should update a reaction instance', async () => {
+      let newReactionInstance = await (new ReactionInstance(sampleReactionInstance)).save()
+      const res = await chai.request('http://localhost:3000')
+        .put(`/api/v1.0/reaction-instance/${newReactionInstance.id}`)
+        .send(Object.assign(sampleReactionInstance, { resourceId: 12345 }))
+
+      expect(res).to.have.status(OK)
+    })
   })
 
   describe('#delete', () => {
-    it('should remove a user')
+    it('should remove a reaction instance', async () => {
+      let newReactionInstance = await (new ReactionInstance(sampleReactionInstance)).save()
+      const res = await chai.request('http://localhost:3000')
+        .delete(`/api/v1.0/reaction-instance/${newReactionInstance.id}`)
+
+      expect(res).to.have.status(NO_CONTENT)
+    })
   })
 })

--- a/test/reactions/api/reaction-rule.js
+++ b/test/reactions/api/reaction-rule.js
@@ -115,7 +115,7 @@ describe('/api/v1.0/reaction-rule', () => {
         .put(`/api/v1.0/reaction-rule/${newReactionRule.id}`)
         .send(Object.assign(sampleReactionRule, { name: 'UpdatedName' }))
 
-      expect(res).to.have.status(NO_CONTENT)
+      expect(res).to.have.status(OK)
     })
   })
 


### PR DESCRIPTION
This pull request also fixes a problem in `main.js` where having a .env file with CONFIG.MONGO_URL defined, all the `npm run test` where done with the `dev` DB
```
if (process.env.NODE_ENV === 'test' && !CONFIG.MONGO_URL) {
  CONFIG.MONGO_URL = 'mongodb://localhost/DemocracyOS-test'
}
```
Changed to
```
if (process.env.NODE_ENV === 'test' && !CONFIG.MONGO_URL_TEST) {
 CONFIG.MONGO_URL = 'mongodb://localhost/DemocracyOS-test'
}
```

Other changes:

* Fixed test issues with reaction rules
* Created API for reaction instances 
* Create tests for reaction instances API 
* Update tests for reaction instances DB-API