### PR TITLE
[v3] Adding reaction instances for the admin panel

### DIFF
--- a/cms/components/admin.js
+++ b/cms/components/admin.js
@@ -1,22 +1,25 @@
 import React from 'react'
 import createHistory from 'history/createBrowserHistory'
-const history = createHistory()
 import { Admin, Resource, Delete } from 'admin-on-rest'
 import RestClient from '../../client/rest-client'
 import CustomRoutes from '../../client/custom-routes'
 import Dashboard from './dashboard'
 import Navbar from './navbar'
 import { ReactionRuleList, ReactionRuleCreate, ReactionRuleEdit } from '../../reactions/components/reaction-rule'
+import { ReactionInstanceList, ReactionInstanceCreate, ReactionInstanceEdit, ReactionInstanceShow } from '../../reactions/components/reaction-instance'
 import { PostList } from './posts/post-list'
 import { PostShow } from './posts/post-show'
 import { PostCreate } from './posts/post-create'
 import { PostEdit } from './posts/post-edit'
 import { UserList, UserView } from '../../users/components/users'
 
+const history = createHistory()
+
 export default (props) => (
   <Admin menu={Navbar} title='Democracy OS' restClient={RestClient} customRoutes={CustomRoutes} history={history} >
     <Resource name='posts' list={PostList} show={PostShow} create={PostCreate} edit={PostEdit} remove={Delete} />
     <Resource name='reaction-rule' options={{ label: 'Reaction Rules' }} list={ReactionRuleList} create={ReactionRuleCreate} edit={ReactionRuleEdit} />
+    <Resource name='reaction-instance' options={{ label: 'Reaction Instances' }} show={ReactionInstanceShow} list={ReactionInstanceList} create={ReactionInstanceCreate} edit={ReactionInstanceEdit} />
     <Resource name='users' list={UserList} edit={UserView} />
   </Admin>
 )

--- a/cms/components/navbar.js
+++ b/cms/components/navbar.js
@@ -8,6 +8,7 @@ const Navbar = ({ resources, onMenuTap, logout }) => (
     <MenuItemLink to='/admin/settings' primaryText='Settings' onClick={onMenuTap} />
     <MenuItemLink to='/admin/posts' primaryText='Posts' onClick={onMenuTap} />
     <MenuItemLink to='/admin/reaction-rule' primaryText='Reaction Rules' onClick={onMenuTap} />
+    <MenuItemLink to='/admin/reaction-instance' primaryText='Reaction Instances' onClick={onMenuTap} />
     <MenuItemLink to='/admin/users' primaryText='Users' onClick={onMenuTap} />
   </nav>
 )

--- a/cms/components/posts/post-create.js
+++ b/cms/components/posts/post-create.js
@@ -15,7 +15,7 @@ import { ContentInput } from './post-content-input'
 
 export const PostCreate = (props) => (
   <Create title={<PostTitle />} {...props}>
-    <SimpleForm>
+    <SimpleForm redirect='/reaction-instance/create?fromCreation=true'>
       <TextInput source='title' />
       <TextInput source='description' options={{ multiLine: true }} />
       <ContentInput label='Content' source='content' addLabel label='Content'/>

--- a/reactions/components/FromCreateContentDialog.js
+++ b/reactions/components/FromCreateContentDialog.js
@@ -1,0 +1,67 @@
+import { Field } from 'redux-form'
+import React from 'react'
+import Dialog from 'material-ui/Dialog'
+import FlatButton from 'material-ui/FlatButton'
+
+class FromCreateContent extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      showDialog: (this.getQueryVariable('fromCreation') === 'true')
+    }
+    this.style = {
+      // toggle: {
+      //   marginBottom: 16,
+      //   marginTop: 16
+      // }
+    }
+    this.actions = [
+      <FlatButton
+        label='Ok!'
+        primary
+        onClick={this.handleClose} />
+    ]
+  }
+
+  getQueryVariable = (variable) => {
+    let query = window.location.search.substring(1)
+    let vars = query.split('&')
+    for (let i = 0; i < vars.length; i++) {
+      let pair = vars[i].split('=')
+      if (pair[0] === variable) {
+        return pair[1]
+      }
+    }
+    return (false)
+  }
+
+  handleClose = () => {
+    this.setState({ showDialog: false })
+  }
+
+  render () {
+    return (
+      <div>
+        {this.getQueryVariable('fromCreation')
+          ? <Dialog
+            title='Add a Reaction?'
+            modal={false}
+            actions={this.actions}
+            open={this.state.showDialog}
+            onRequestClose={this.handleClose}>
+            You've just created a content! You can create reactions for your content by creating a reaction Instance. Just select the content and the rule and you are all set!
+          </Dialog>
+          : null
+        }
+      </div>
+    )
+  }
+}
+
+const FromCreateContentDialog = () => (
+  <span>
+    <Field component={FromCreateContent} />
+  </span>
+)
+
+export default FromCreateContentDialog

--- a/reactions/components/reaction-instance.js
+++ b/reactions/components/reaction-instance.js
@@ -1,26 +1,6 @@
 import React from 'react'
 import { ReferenceField, ShowButton, SimpleShowLayout, Show, ReferenceInput, Datagrid, FunctionField, NumberField, TextField, Create, Edit, SimpleForm, TextInput, SelectInput, DateInput, DateField, EditButton, DeleteButton, List, required, NumberInput, BooleanInput } from 'admin-on-rest'
-// import ClosingDateField from './ClosingDateField'
-// const METHODS = require('../enum/methods')
-// import BookIcon from 'material-ui/svg-icons/action/book'
-// export const PostIcon = BookIcon
-
-// const getChoices = () => {
-//   let choicesArray = []
-//   METHODS.forEach((method) => {
-//     choicesArray.push({
-//       id: method,
-//       name: method
-//     })
-//   })
-//   return choicesArray
-// }
-
-// const minClosingDate = () => {
-//   let date = new Date()
-//   date.setDate(date.getDate() + 1)
-//   return date
-// }
+import FromCreateContentDialog from './FromCreateContentDialog'
 
 export const ReactionInstanceList = (props) => (
   <List {...props} title='List of reaction instances'>
@@ -41,17 +21,14 @@ export const ReactionInstanceList = (props) => (
 export const ReactionInstanceCreate = (props) => (
   <Create {...props} title='Create a reaction instances'>
     <SimpleForm>
+      <FromCreateContentDialog />
       <ReferenceInput label='Select a content' source='resourceId' reference='posts' allowEmpty validate={required}>
         <SelectInput optionText='title' />
       </ReferenceInput>
       <ReferenceInput label='Select a rule' source='reactionId' reference='reaction-rule' allowEmpty validate={required}>
         <SelectInput optionText='name' />
       </ReferenceInput>
-      {/* <TextInput source='name' label='Name your rule' />
-      <SelectInput source='method' label='Type of Reaction' choices={getChoices()} />
-      <NumberInput source='limit' step={1} />
-      <DateInput label='Opening date' source='startingDate' defaultValue={new Date()} options={{ minDate: new Date() }} />
-      <DateInput label='Closing date' source='closingDate' options={{ minDate: minClosingDate() }} /> */}
+
     </SimpleForm>
   </Create>
 )
@@ -59,12 +36,7 @@ export const ReactionInstanceCreate = (props) => (
 export const ReactionInstanceEdit = (props) => (
   <Edit {...props} title='Edit a reaction instances'>
     <SimpleForm>
-      {/* <TextInput source='name' label='Name your rule' />
-      <TextField source='method' label='Type of Reaction' />
-      <NumberInput source='limit' step={1} />
-      <DateField label='Opening date' source='startingDate' /> */}
-      {/* <DateInput label='Closing date' source='closingDate' options={{ minDate: minClosingDate() }} /> */}
-      {/* <ClosingDateField /> */}
+      <span>Soon..</span>
     </SimpleForm>
   </Edit>
 )

--- a/reactions/components/reaction-instance.js
+++ b/reactions/components/reaction-instance.js
@@ -1,0 +1,88 @@
+import React from 'react'
+import { ReferenceField, ShowButton, SimpleShowLayout, Show, ReferenceInput, Datagrid, FunctionField, NumberField, TextField, Create, Edit, SimpleForm, TextInput, SelectInput, DateInput, DateField, EditButton, DeleteButton, List, required, NumberInput, BooleanInput } from 'admin-on-rest'
+// import ClosingDateField from './ClosingDateField'
+// const METHODS = require('../enum/methods')
+// import BookIcon from 'material-ui/svg-icons/action/book'
+// export const PostIcon = BookIcon
+
+// const getChoices = () => {
+//   let choicesArray = []
+//   METHODS.forEach((method) => {
+//     choicesArray.push({
+//       id: method,
+//       name: method
+//     })
+//   })
+//   return choicesArray
+// }
+
+// const minClosingDate = () => {
+//   let date = new Date()
+//   date.setDate(date.getDate() + 1)
+//   return date
+// }
+
+export const ReactionInstanceList = (props) => (
+  <List {...props} title='List of reaction instances'>
+    <Datagrid>
+      <ReferenceField label='Resource' source='resourceId' reference='posts' linkType='show'>
+        <TextField source='title' />
+      </ReferenceField>
+      <ReferenceField label='Rule' source='reactionId' reference='reaction-rule'>
+        <TextField source='name' />
+      </ReferenceField>
+      <ShowButton />
+      <EditButton style={{ textAlign: 'center' }} />
+      <DeleteButton style={{ textAlign: 'center' }} />
+    </Datagrid>
+  </List>
+)
+
+export const ReactionInstanceCreate = (props) => (
+  <Create {...props} title='Create a reaction instances'>
+    <SimpleForm>
+      <ReferenceInput label='Select a content' source='resourceId' reference='posts' allowEmpty validate={required}>
+        <SelectInput optionText='title' />
+      </ReferenceInput>
+      <ReferenceInput label='Select a rule' source='reactionId' reference='reaction-rule' allowEmpty validate={required}>
+        <SelectInput optionText='name' />
+      </ReferenceInput>
+      {/* <TextInput source='name' label='Name your rule' />
+      <SelectInput source='method' label='Type of Reaction' choices={getChoices()} />
+      <NumberInput source='limit' step={1} />
+      <DateInput label='Opening date' source='startingDate' defaultValue={new Date()} options={{ minDate: new Date() }} />
+      <DateInput label='Closing date' source='closingDate' options={{ minDate: minClosingDate() }} /> */}
+    </SimpleForm>
+  </Create>
+)
+
+export const ReactionInstanceEdit = (props) => (
+  <Edit {...props} title='Edit a reaction instances'>
+    <SimpleForm>
+      {/* <TextInput source='name' label='Name your rule' />
+      <TextField source='method' label='Type of Reaction' />
+      <NumberInput source='limit' step={1} />
+      <DateField label='Opening date' source='startingDate' /> */}
+      {/* <DateInput label='Closing date' source='closingDate' options={{ minDate: minClosingDate() }} /> */}
+      {/* <ClosingDateField /> */}
+    </SimpleForm>
+  </Edit>
+)
+
+export const ReactionInstanceShow = (props) => (
+  <Show {...props}>
+    <SimpleShowLayout>
+      <DateField source='createdAt' label='Created' />
+      <FunctionField label='Results' render={(record) => `${record.results.length}`} />
+      <ReferenceField label='Select a content' source='resourceId' reference='posts' linkType='show'>
+        <TextField source='title' />
+      </ReferenceField>
+      <ReferenceField label='Select a rule' source='reactionId' reference='reaction-rule'>
+        <TextField source='name' />
+      </ReferenceField>
+      <ReferenceField label='Type of rule' source='reactionId' reference='reaction-rule' linkType={false}>
+        <TextField source='method' />
+      </ReferenceField>
+    </SimpleShowLayout>
+  </Show>
+)

--- a/reactions/components/reactions-routes.js
+++ b/reactions/components/reactions-routes.js
@@ -2,10 +2,16 @@ import React from 'react'
 import { Route } from 'react-router-dom'
 import { Delete } from 'admin-on-rest'
 import { ReactionRuleList, ReactionRuleCreate, ReactionRuleEdit } from './reaction-rule'
+import { ReactionInstanceList, ReactionInstanceCreate, ReactionInstanceEdit, ReactionInstanceShow } from './reaction-instance'
 
 export default [
-  <Route exact path='/admin/reaction-rule' render={(routeProps) => <ReactionRuleList hasCreate={true} resource='reaction-rule' {...routeProps} />} />,
+  <Route exact path='/admin/reaction-rule' render={(routeProps) => <ReactionRuleList hasCreate resource='reaction-rule' {...routeProps} />} />,
   <Route exact path='/admin/reaction-rule/create' render={(routeProps) => <ReactionRuleCreate resource='reaction-rule' {...routeProps} />} />,
   <Route exact path='/admin/reaction-rule/:id' render={(routeProps) => <ReactionRuleEdit resource='reaction-rule' {...routeProps} />} />,
-  <Route exact path='/admin/reaction-rule/:id/delete' render={(routeProps) => <Delete resource='reaction-rule' {...routeProps} />} />
+  <Route exact path='/admin/reaction-rule/:id/delete' render={(routeProps) => <Delete resource='reaction-rule' {...routeProps} />} />,
+  <Route exact path='/admin/reaction-instance' render={(routeProps) => <ReactionInstanceList hasCreate resource='reaction-instance' {...routeProps} />} />,
+  <Route exact path='/admin/reaction-instance/create' render={(routeProps) => <ReactionInstanceCreate resource='reaction-instance' {...routeProps} />} />,
+  <Route exact path='/admin/reaction-instance/:id' render={(routeProps) => <ReactionInstanceEdit resource='reaction-instance' {...routeProps} />} />,
+  <Route exact path='/admin/reaction-instance/:id/show' render={(routeProps) => <ReactionInstanceShow resource='reaction-instance' {...routeProps} />} />,
+  <Route exact path='/admin/reaction-instance/:id/delete' render={(routeProps) => <Delete resource='reaction-instance' {...routeProps} />} />
 ]


### PR DESCRIPTION
Now the admin panel has reaction instances.
A few changes:

- New panel for reaction instances
- List, Create, Edit (Not working) and Remove components working (we have to discuss this last two)
- Now after creating a post it takes you to create a reaction instance (and it shows a fancy dialog asking if you want to create it) (*)

(*) The strategy is:
1. It redirects to `/reaction-instance/create?fromCreation=true`
2. The `<Create>` component has a "custom field" that checks if the query has a param called `fromCreation`
3. If its true it shows a dialog encouraging the admin to create a reaction instance.