### PR TITLE
[v3] Added Reactions Service - Results for Reaction Instances and Posts

### DIFF
--- a/main/api.js
+++ b/main/api.js
@@ -21,6 +21,7 @@ router.use('/reaction-rule', require('../reactions/api/reaction-rule'))
 router.use('/reaction-instance', require('../reactions/api/reaction-instance'))
 router.use('/reaction-vote', require('../reactions/api/reaction-vote'))
 router.use('/posts', require('../cms/api/posts'))
+router.use('/services/reactions', require('../services/reactions'))
 
 // Catch 404 and forward to error handler.
 router.use((req, res, next) => {

--- a/reactions/api/reaction-vote.js
+++ b/reactions/api/reaction-vote.js
@@ -25,8 +25,7 @@ router.route('/')
   // GET reaction-vote
   .get(async (req, res, next) => {
     try {
-      const results = await ReactionVote.list({ limit: req.query.limit, page: req.query.page })
-
+      const results = await ReactionVote.list({ limit: req.query.limit, page: req.query.page, ids: req.query.ids })
       res.status(OK).json({
         results: results.docs,
         pagination: {

--- a/reactions/components/ReactionResult.js
+++ b/reactions/components/ReactionResult.js
@@ -8,6 +8,7 @@ import {
   CardHeader,
   CardText
 } from 'material-ui'
+import { Link } from 'react-router-dom'
 
 class ReactionResult extends React.Component {
   constructor (props) {
@@ -71,7 +72,7 @@ class ReactionResult extends React.Component {
     const listUsers = this.state.instanceResult.participants.length > 0
       ? this.state.instanceResult.participants.map((x) => {
         return (
-          <ListItem primaryText={x.name} />
+          <ListItem containerElement={<Link to={'/admin/users/' + x._id} />} primaryText={x.name} />
         )
       }) : (
         <p>No users have participated yet</p>

--- a/reactions/components/ReactionResult.js
+++ b/reactions/components/ReactionResult.js
@@ -1,0 +1,100 @@
+import React from 'react'
+import Paper from 'material-ui/Paper'
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  TableHeaderColumn,
+  TableRow,
+  TableRowColumn
+} from 'material-ui/Table'
+import {
+  ReferenceField,
+  TextField
+} from 'admin-on-rest'
+import { Card, CardActions, CardHeader, CardText } from 'material-ui/Card'
+
+class ReactionResult extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      // reactionIds: props.record.results,
+      instanceResult: {
+        data: []
+      },
+      reactionRule: {
+        name: ''
+      }
+    }
+    this.style = {
+
+    }
+  }
+  componentWillMount () {
+    let params = {
+      limit: '2',
+      page: '1',
+      ids: JSON.stringify(this.props.record.results)
+    }
+
+    let esc = encodeURIComponent
+    let query = Object.keys(params)
+      .map((k) => esc(k) + '=' + esc(params[k]))
+      // .map((k) => k + '=' + params[k])
+      .join('&')
+
+    fetch('/api/v1.0/services/reactions/' + this.props.record._id + '/result', {
+      method: 'GET',
+      headers: new Headers({
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      })
+    }).then((res) => res.json())
+      .then((response) => {
+        console.log('Success:', response)
+        this.setState({ instanceResult: response })
+      })
+      .catch((error) => console.error('Error:', error))
+    fetch('/api/v1.0/reaction-rule/' + this.props.record.reactionId, {
+      method: 'GET',
+      headers: new Headers({
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      })
+    }).then((res) => res.json())
+      .then((response) => {
+        console.log('Success:', response)
+        this.setState({ reactionRule: response })
+      })
+      .catch((error) => console.error('Error:', error))
+  }
+
+  render () {
+    const style = {
+      position: 'absolute',
+      right: '60px' /* Magic! */
+    }
+
+    return (
+      <Card style={style}>
+        <CardHeader
+          title='Results'
+          subtitle={'Reaction Rule: ' + this.state.reactionRule.name} />
+        <CardText>
+          {this.state.instanceResult.data.map(function (data) {
+            return (<p>Option: {data.option} - Count: {data.value}</p>)
+          })
+          }
+        </CardText>
+      </Card >
+    )
+  }
+}
+
+// const ClosingDateField = () => (
+//   <span>
+//     <Field name='closingDate' component={NullClosingDate} label='Closing Date' />
+//   </span>
+// )
+
+export default ReactionResult

--- a/reactions/components/ReactionResult.js
+++ b/reactions/components/ReactionResult.js
@@ -1,48 +1,30 @@
 import React from 'react'
-import Paper from 'material-ui/Paper'
 import {
-  Table,
-  TableBody,
-  TableHeader,
-  TableHeaderColumn,
-  TableRow,
-  TableRowColumn
-} from 'material-ui/Table'
-import {
-  ReferenceField,
-  TextField
-} from 'admin-on-rest'
-import { Card, CardActions, CardHeader, CardText } from 'material-ui/Card'
+  Dialog,
+  FlatButton,
+  ListItem,
+  Card,
+  CardActions,
+  CardHeader,
+  CardText
+} from 'material-ui'
 
 class ReactionResult extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
-      // reactionIds: props.record.results,
       instanceResult: {
-        data: []
+        data: [],
+        participants: [],
+        reactionRule: {}
       },
-      reactionRule: {
-        name: ''
-      }
+      showParticipants: false
     }
     this.style = {
 
     }
   }
   componentWillMount () {
-    let params = {
-      limit: '2',
-      page: '1',
-      ids: JSON.stringify(this.props.record.results)
-    }
-
-    let esc = encodeURIComponent
-    let query = Object.keys(params)
-      .map((k) => esc(k) + '=' + esc(params[k]))
-      // .map((k) => k + '=' + params[k])
-      .join('&')
-
     fetch('/api/v1.0/services/reactions/' + this.props.record._id + '/result', {
       method: 'GET',
       headers: new Headers({
@@ -55,46 +37,72 @@ class ReactionResult extends React.Component {
         this.setState({ instanceResult: response })
       })
       .catch((error) => console.error('Error:', error))
-    fetch('/api/v1.0/reaction-rule/' + this.props.record.reactionId, {
-      method: 'GET',
-      headers: new Headers({
-        'Content-Type': 'application/json',
-        'Accept': 'application/json'
-      })
-    }).then((res) => res.json())
-      .then((response) => {
-        console.log('Success:', response)
-        this.setState({ reactionRule: response })
-      })
-      .catch((error) => console.error('Error:', error))
   }
+  handleOpen = () => {
+    this.setState({ showParticipants: true })
+  };
+
+  handleClose = () => {
+    this.setState({ showParticipants: false })
+  };
 
   render () {
-    const style = {
-      position: 'absolute',
-      right: '60px' /* Magic! */
+    const styles = {
+
+      counter: {
+        title: {
+          textAlign: 'center',
+          fontWeight: '400'
+        },
+        number: {
+          textAlign: 'center',
+          fontSize: '3rem'
+        },
+        chip: {
+          margin: 4
+        },
+        wrapper: {
+          display: 'flex',
+          flexWrap: 'wrap'
+        }
+      }
     }
 
+    const listUsers = this.state.instanceResult.participants.length > 0
+      ? this.state.instanceResult.participants.map((x) => {
+        return (
+          <ListItem primaryText={x.name} />
+        )
+      }) : (
+        <p>No users have participated yet</p>
+      )
+
+    // CARD for ReactionLIKE
     return (
-      <Card style={style}>
-        <CardHeader
-          title='Results'
-          subtitle={'Reaction Rule: ' + this.state.reactionRule.name} />
-        <CardText>
-          {this.state.instanceResult.data.map(function (data) {
-            return (<p>Option: {data.option} - Count: {data.value}</p>)
-          })
-          }
-        </CardText>
-      </Card >
+      <div>
+        <Card>
+          <CardHeader
+            title={this.state.instanceResult.reactionRule.method + ' Results'}
+            subtitle={'Reaction Rule: ' + this.state.instanceResult.reactionRule.name} />
+          <CardText>
+            <h3 style={styles.counter.title}>LIKES</h3>
+            <h1 style={styles.counter.number}>{this.state.instanceResult.data.value}</h1>
+          </CardText>
+          <CardActions>
+            <FlatButton label='List participants' onClick={this.handleOpen} />
+          </CardActions>
+        </Card >
+        <Dialog
+          title='List of participants'
+          modal={false}
+          open={this.state.showParticipants}
+          onRequestClose={this.handleClose}
+          autoScrollBodyContent>
+          {listUsers}
+        </Dialog>
+      </div>
     )
   }
 }
-
-// const ClosingDateField = () => (
-//   <span>
-//     <Field name='closingDate' component={NullClosingDate} label='Closing Date' />
-//   </span>
-// )
 
 export default ReactionResult

--- a/reactions/components/reaction-instance.js
+++ b/reactions/components/reaction-instance.js
@@ -59,21 +59,32 @@ export const ReactionInstanceEdit = (props) => (
   </Edit>
 )
 
+const styleShow = {
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'auto auto'
+  }
+}
+
 export const ReactionInstanceShow = (props) => (
   <Show {...props} title='Reaction Instance'>
-    <SimpleShowLayout>
-      <ReactionResult />
-      <DateField source='createdAt' label='Created' />
-      <FunctionField label='Results' render={(record) => `${record.results.length}`} />
-      <ReferenceField label='Content title' source='resourceId' reference='posts' linkType='show'>
-        <TextField source='title' />
-      </ReferenceField>
-      <ReferenceField label='Name of the rule' source='reactionId' reference='reaction-rule'>
-        <TextField source='name' />
-      </ReferenceField>
-      <ReferenceField label='Type of rule' source='reactionId' reference='reaction-rule' linkType={false}>
-        <TextField source='method' />
-      </ReferenceField>
+    <SimpleShowLayout style={styleShow.grid}>
+      <SimpleShowLayout>
+        <DateField source='createdAt' label='Created' />
+        <FunctionField label='Results' render={(record) => `${record.results.length}`} />
+        <ReferenceField label='Content title' source='resourceId' reference='posts' linkType='show'>
+          <TextField source='title' />
+        </ReferenceField>
+        <ReferenceField label='Name of the rule' source='reactionId' reference='reaction-rule'>
+          <TextField source='name' />
+        </ReferenceField>
+        <ReferenceField label='Type of rule' source='reactionId' reference='reaction-rule' linkType={false}>
+          <TextField source='method' />
+        </ReferenceField>
+      </SimpleShowLayout>
+      <SimpleShowLayout>
+        <ReactionResult />
+      </SimpleShowLayout>
     </SimpleShowLayout>
   </Show>
 )

--- a/reactions/components/reaction-instance.js
+++ b/reactions/components/reaction-instance.js
@@ -1,6 +1,25 @@
 import React from 'react'
-import { ReferenceField, ShowButton, SimpleShowLayout, Show, ReferenceInput, Datagrid, FunctionField, NumberField, TextField, Create, Edit, SimpleForm, TextInput, SelectInput, DateInput, DateField, EditButton, DeleteButton, List, required, NumberInput, BooleanInput } from 'admin-on-rest'
+import {
+  ReferenceField,
+  ShowButton,
+  SimpleShowLayout,
+  Show,
+  ReferenceInput,
+  Datagrid,
+  FunctionField,
+  TextField,
+  Create,
+  Edit,
+  SimpleForm,
+  SelectInput,
+  DateField,
+  EditButton,
+  DeleteButton,
+  List,
+  required
+} from 'admin-on-rest'
 import FromCreateContentDialog from './FromCreateContentDialog'
+import ReactionResult from './ReactionResult'
 
 export const ReactionInstanceList = (props) => (
   <List {...props} title='List of reaction instances'>
@@ -28,7 +47,6 @@ export const ReactionInstanceCreate = (props) => (
       <ReferenceInput label='Select a rule' source='reactionId' reference='reaction-rule' allowEmpty validate={required}>
         <SelectInput optionText='name' />
       </ReferenceInput>
-
     </SimpleForm>
   </Create>
 )
@@ -42,14 +60,15 @@ export const ReactionInstanceEdit = (props) => (
 )
 
 export const ReactionInstanceShow = (props) => (
-  <Show {...props}>
+  <Show {...props} title='Reaction Instance'>
     <SimpleShowLayout>
+      <ReactionResult />
       <DateField source='createdAt' label='Created' />
       <FunctionField label='Results' render={(record) => `${record.results.length}`} />
-      <ReferenceField label='Select a content' source='resourceId' reference='posts' linkType='show'>
+      <ReferenceField label='Content title' source='resourceId' reference='posts' linkType='show'>
         <TextField source='title' />
       </ReferenceField>
-      <ReferenceField label='Select a rule' source='reactionId' reference='reaction-rule'>
+      <ReferenceField label='Name of the rule' source='reactionId' reference='reaction-rule'>
         <TextField source='name' />
       </ReferenceField>
       <ReferenceField label='Type of rule' source='reactionId' reference='reaction-rule' linkType={false}>

--- a/reactions/components/reaction-rule.js
+++ b/reactions/components/reaction-rule.js
@@ -1,5 +1,18 @@
 import React from 'react'
-import { Datagrid, TextField, Create, Edit, SimpleForm, Filter, TextInput, SelectInput, DateInput, DateField, EditButton, DeleteButton, List, NumberInput, BooleanInput } from 'admin-on-rest'
+import { Datagrid,
+  TextField,
+  Create,
+  Edit,
+  SimpleForm,
+  Filter,
+  TextInput,
+  SelectInput,
+  DateInput,
+  DateField,
+  EditButton,
+  DeleteButton,
+  List,
+  NumberInput } from 'admin-on-rest'
 import ClosingDateField from './ClosingDateField'
 const METHODS = require('../enum/methods')
 // import BookIcon from 'material-ui/svg-icons/action/book'

--- a/reactions/db-api/reaction-instance.js
+++ b/reactions/db-api/reaction-instance.js
@@ -58,8 +58,8 @@ exports.list = function list ({ filter, limit, page, ids }) {
 }
 
 /**
- * Update listByPost
- * @method listByPost
+ * Update listResultsByPost
+ * @method list
  * @param  {object} id
  * @param  {string} limit
  * @param  {object} page
@@ -68,8 +68,17 @@ exports.list = function list ({ filter, limit, page, ids }) {
 
 exports.listResultsByPost = function listResultsByPost ({ id, limit, page }) {
   log.debug('get reactionInstances results list by post id')
-  return ReactionInstance.paginate({ resourceId: ObjectId(id) }, { page, limit, populate: { path: 'results' } })
+  return ReactionInstance.paginate({ resourceId: ObjectId(id) }, { page, limit, populate: { path: 'results reactionId', populate: { path: 'userId', select: 'name _id' } } })
 }
+
+/**
+ * Update getResult
+ * @method get
+ * @param  {object} id
+ * @param  {string} limit
+ * @param  {object} page
+ * @return {promise}
+ */
 
 exports.getResult = function getResult ({ id }) {
   log.debug('get reactionInstance result')

--- a/reactions/db-api/reaction-instance.js
+++ b/reactions/db-api/reaction-instance.js
@@ -71,9 +71,9 @@ exports.listResultsByPost = function listResultsByPost ({ id, limit, page }) {
   return ReactionInstance.paginate({ resourceId: ObjectId(id) }, { page, limit, populate: { path: 'results' } })
 }
 
-exports.getResult = function getResult ({ id, limit, page }) {
+exports.getResult = function getResult ({ id }) {
   log.debug('get reactionInstance result')
-  return ReactionInstance.findOne({ _id: ObjectId(id) }).populate('results')
+  return ReactionInstance.findOne({ _id: ObjectId(id) }).populate({ path: 'results', populate: { path: 'userId', select: 'name _id' } }).populate('reactionId')
 }
 
 /**

--- a/reactions/db-api/reaction-instance.js
+++ b/reactions/db-api/reaction-instance.js
@@ -66,9 +66,9 @@ exports.list = function list ({ filter, limit, page, ids }) {
  * @return {promise}
  */
 
-exports.listResultsByPost = function listResultsByPost ({ id, limit, page }) {
+exports.listResultsByPost = function listResultsByPost ({ id }) {
   log.debug('get reactionInstances results list by post id')
-  return ReactionInstance.paginate({ resourceId: ObjectId(id) }, { page, limit, populate: { path: 'results reactionId', populate: { path: 'userId', select: 'name _id' } } })
+  return ReactionInstance.find({ resourceId: ObjectId(id) }).populate({ path: 'results', populate: { path: 'userId', select: 'name _id' } }).populate('reactionId')
 }
 
 /**

--- a/reactions/db-api/reaction-instance.js
+++ b/reactions/db-api/reaction-instance.js
@@ -56,6 +56,20 @@ exports.list = function list ({ filter, limit, page, ids }) {
   return ReactionInstance
     .paginate({}, { page, limit })
 }
+
+/**
+ * Update listByPost
+ * @method listByPost
+ * @param  {object} id
+ * @param  {string} limit
+ * @param  {object} page
+ * @return {promise}
+ */
+
+exports.listByPost = function listByPost ({ id, limit, page }) {
+  log.debug('get reactionInstances list by post id')
+  return ReactionInstance.paginate({ resourceId: ObjectId(id) }, { page, limit , populate: {path: 'results'} })
+}
 /**
  * Update reactionInstance
  * @method update

--- a/reactions/db-api/reaction-instance.js
+++ b/reactions/db-api/reaction-instance.js
@@ -66,10 +66,16 @@ exports.list = function list ({ filter, limit, page, ids }) {
  * @return {promise}
  */
 
-exports.listByPost = function listByPost ({ id, limit, page }) {
-  log.debug('get reactionInstances list by post id')
-  return ReactionInstance.paginate({ resourceId: ObjectId(id) }, { page, limit , populate: {path: 'results'} })
+exports.listResultsByPost = function listResultsByPost ({ id, limit, page }) {
+  log.debug('get reactionInstances results list by post id')
+  return ReactionInstance.paginate({ resourceId: ObjectId(id) }, { page, limit, populate: { path: 'results' } })
 }
+
+exports.getResult = function getResult ({ id, limit, page }) {
+  log.debug('get reactionInstance result')
+  return ReactionInstance.findOne({ _id: ObjectId(id) }).populate('results')
+}
+
 /**
  * Update reactionInstance
  * @method update

--- a/reactions/db-api/reaction-vote.js
+++ b/reactions/db-api/reaction-vote.js
@@ -35,8 +35,15 @@ exports.get = function get (id) {
  * @return {promise}
  */
 
-exports.list = function list ({ limit, page }) {
+exports.list = function list ({ limit, page, ids }) {
   log.debug('get reactionVote list')
+  if (ids) {
+    const idsToArray = JSON.parse(ids)
+    idsToArray.map((id) => {
+      return ObjectId(id)
+    })
+    return ReactionVote.paginate({ '_id': { $in: idsToArray } }, { page, limit })
+  }
   return ReactionVote
     .paginate({}, { page, limit })
 }

--- a/reactions/models/reaction-instance.js
+++ b/reactions/models/reaction-instance.js
@@ -9,7 +9,7 @@ const ReactionInstance = new mongoose.Schema({
   reactionId: { type: mongoose.Schema.Types.ObjectId, refPath: 'reactionRule' },
   resourceType: String,
   resourceId: String,
-  results: [{}]
+  results: [{ type: mongoose.Schema.Types.ObjectId, ref: 'ReactionVote' }]
 }, { timestamps: true })
 
 /**

--- a/reactions/models/reaction-instance.js
+++ b/reactions/models/reaction-instance.js
@@ -6,7 +6,7 @@ const mongoosePaginate = require('mongoose-paginate')
  */
 
 const ReactionInstance = new mongoose.Schema({
-  reactionId: { type: mongoose.Schema.Types.ObjectId, refPath: 'reactionRule' },
+  reactionId: { type: mongoose.Schema.Types.ObjectId, ref: 'ReactionRule' },
   resourceType: String,
   resourceId: String,
   results: [{ type: mongoose.Schema.Types.ObjectId, ref: 'ReactionVote' }]

--- a/services/reactions.js
+++ b/services/reactions.js
@@ -55,28 +55,43 @@ router.route('/posts/:id/results')
   .get(async (req, res, next) => {
     try {
       const results = await ReactionInstance.listResultsByPost({ id: req.params.id, limit: req.query.limit, page: req.query.page })
-      let dataSet = []
+      let dataArray = []
       results.docs.forEach((instance) => {
-        let options = new Set()
-        let frequency = []
-        let instanceResults = []
-        instance.results.forEach((vote) => {
-          options.add(vote.value)
-          frequency[vote.value] = (frequency[vote.value] ? frequency[vote.value] : 0) + 1
-        })
-        options.forEach((option) => {
-          instanceResults.push({
-            option: option,
-            value: frequency[option]
-          })
-        })
-        dataSet.push({
-          id: instance._id,
-          data: instanceResults
-        })
+        let dataInstance = {}
+        // let options = new Set()
+        // let frequency = []
+        // let instanceResults = []
+        // instance.results.forEach((vote) => {
+        //   options.add(vote.value)
+        //   frequency[vote.value] = (frequency[vote.value] ? frequency[vote.value] : 0) + 1
+        // })
+        // options.forEach((option) => {
+        //   instanceResults.push({
+        //     option: option,
+        //     value: frequency[option]
+        //   })
+        // })
+        // dataSet.push({
+        //   id: instance._id,
+        //   data: instanceResults
+        // })
+        console.log(instance)
+        switch (instance.reactionId.method) {
+          case 'LIKE':
+            dataInstance = dataForLike(instance)
+            break
+          // This is for future implementations..
+          // Depending of the type of rule, it needs to process data in a different way
+          case 'VOTE':
+            dataInstance = dataForChoose(instance)
+            break
+          default:
+            break
+        }
+        dataArray.push(dataInstance)
       })
 
-      res.status(OK).json(dataSet)
+      res.status(OK).json(dataArray)
     } catch (err) {
       next(err)
     }

--- a/services/reactions.js
+++ b/services/reactions.js
@@ -54,28 +54,11 @@ router.route('/posts/:id/results')
   // GET reaction-instances
   .get(async (req, res, next) => {
     try {
-      const results = await ReactionInstance.listResultsByPost({ id: req.params.id, limit: req.query.limit, page: req.query.page })
+      const instances = await ReactionInstance.listResultsByPost({ id: req.params.id })
       let dataArray = []
-      results.docs.forEach((instance) => {
+      instances.forEach((instance) => {
         let dataInstance = {}
-        // let options = new Set()
-        // let frequency = []
-        // let instanceResults = []
-        // instance.results.forEach((vote) => {
-        //   options.add(vote.value)
-        //   frequency[vote.value] = (frequency[vote.value] ? frequency[vote.value] : 0) + 1
-        // })
-        // options.forEach((option) => {
-        //   instanceResults.push({
-        //     option: option,
-        //     value: frequency[option]
-        //   })
-        // })
-        // dataSet.push({
-        //   id: instance._id,
-        //   data: instanceResults
-        // })
-        console.log(instance)
+
         switch (instance.reactionId.method) {
           case 'LIKE':
             dataInstance = dataForLike(instance)

--- a/services/reactions.js
+++ b/services/reactions.js
@@ -1,0 +1,76 @@
+const express = require('express')
+const {
+  OK,
+  CREATED,
+  NO_CONTENT
+} = require('http-status')
+const ReactionInstance = require('../reactions/db-api/reaction-instance')
+// Requires winston lib for log
+const { log } = require('../main/logger')
+// Requires CRUD apis
+const router = express.Router()
+
+router.route('/posts/:id/graphs')
+  // GET reaction-instances
+  .get(async (req, res, next) => {
+    try {
+      const results = await ReactionInstance.listByPost({ id: req.params.id, limit: req.query.limit, page: req.query.page })
+      let dataSet = []
+      results.docs.forEach((instance) => {
+        let options = new Set()
+        let frequency = []
+        let instanceResults = []
+        instance.results.forEach((vote) => {
+          options.add(vote.value)
+          frequency[vote.value] = (frequency[vote.value] ? frequency[vote.value] : 0) + 1
+        })
+        options.forEach((option) => {
+          instanceResults.push({
+            value: option,
+            count: frequency[option]
+          })
+        })
+        dataSet.push({
+          id: instance._id,
+          data: instanceResults
+        })
+      })
+
+      res.status(OK).json(dataSet)
+      // res.status(OK).json({
+      //   results: results.docs,
+      //   pagination: {
+      //     count: results.total,
+      //     page: results.page,
+      //     limit: results.limit
+      //   }
+      // })
+    } catch (err) {
+      next(err)
+    }
+  })
+
+router.route('/:id/graphs')
+  // GET reaction-instances
+  .get(async (req, res, next) => {
+    try {
+      const results = await ReactionInstance.listByPost({ id: req.params.id, limit: req.query.limit, page: req.query.page })
+      let values = new Set()
+      let dataSet = []
+      results.forEach((element) => {
+        values.add(element.value)
+      })
+      res.status(OK).json({
+        results: results.docs,
+        pagination: {
+          count: results.total,
+          page: results.page,
+          limit: results.limit
+        }
+      })
+    } catch (err) {
+      next(err)
+    }
+  })
+
+module.exports = router

--- a/services/reactions.js
+++ b/services/reactions.js
@@ -25,7 +25,7 @@ const dataForLike = function (instance) {
   return data
 }
 
-const dataForVote = function (instance) {
+const dataForChoose = function (instance) {
   let data = null
   let options = new Set()
   let frequency = []
@@ -44,7 +44,8 @@ const dataForVote = function (instance) {
   data = {
     id: instance._id,
     reactionRule: instance.reactionId,
-    data: instanceResults
+    data: instanceResults,
+    participants: userParticipants
   }
   return data
 }
@@ -94,7 +95,7 @@ router.route('/:id/result')
           // This is for future implementations..
           // Depending of the type of rule, it needs to process data in a different way
         case 'VOTE':
-          data = dataForVote(instance)
+          data = dataForChoose(instance)
           break
         default:
           break

--- a/services/reactions.js
+++ b/services/reactions.js
@@ -10,11 +10,11 @@ const { log } = require('../main/logger')
 // Requires CRUD apis
 const router = express.Router()
 
-router.route('/posts/:id/graphs')
+router.route('/posts/:id/results')
   // GET reaction-instances
   .get(async (req, res, next) => {
     try {
-      const results = await ReactionInstance.listByPost({ id: req.params.id, limit: req.query.limit, page: req.query.page })
+      const results = await ReactionInstance.listResultsByPost({ id: req.params.id, limit: req.query.limit, page: req.query.page })
       let dataSet = []
       results.docs.forEach((instance) => {
         let options = new Set()
@@ -26,8 +26,8 @@ router.route('/posts/:id/graphs')
         })
         options.forEach((option) => {
           instanceResults.push({
-            value: option,
-            count: frequency[option]
+            option: option,
+            value: frequency[option]
           })
         })
         dataSet.push({
@@ -37,37 +37,37 @@ router.route('/posts/:id/graphs')
       })
 
       res.status(OK).json(dataSet)
-      // res.status(OK).json({
-      //   results: results.docs,
-      //   pagination: {
-      //     count: results.total,
-      //     page: results.page,
-      //     limit: results.limit
-      //   }
-      // })
     } catch (err) {
       next(err)
     }
   })
 
-router.route('/:id/graphs')
+router.route('/:id/result')
   // GET reaction-instances
   .get(async (req, res, next) => {
     try {
-      const results = await ReactionInstance.listByPost({ id: req.params.id, limit: req.query.limit, page: req.query.page })
-      let values = new Set()
-      let dataSet = []
-      results.forEach((element) => {
-        values.add(element.value)
+      const instance = await ReactionInstance.getResult({ id: req.params.id, limit: req.query.limit, page: req.query.page })
+      let dataSet = null
+      let options = new Set()
+      let frequency = []
+      let instanceResults = []
+      console.log(instance.docs)
+      instance.results.forEach((vote) => {
+        options.add(vote.value)
+        frequency[vote.value] = (frequency[vote.value] ? frequency[vote.value] : 0) + 1
       })
-      res.status(OK).json({
-        results: results.docs,
-        pagination: {
-          count: results.total,
-          page: results.page,
-          limit: results.limit
-        }
+      options.forEach((option) => {
+        instanceResults.push({
+          option: option,
+          value: frequency[option]
+        })
       })
+      dataSet = {
+        id: instance._id,
+        data: instanceResults
+      }
+
+      res.status(OK).json(dataSet)
     } catch (err) {
       next(err)
     }

--- a/test/reactions/api/reaction-instance.js
+++ b/test/reactions/api/reaction-instance.js
@@ -118,9 +118,9 @@ describe('/api/v1.0/reaction-instance', () => {
       const res = await chai.request('http://localhost:3000')
         .delete(`/api/v1.0/reaction-instance/${newReactionInstance.id}`)
 
-        expect(res).to.have.status(OK)
-        expect(res.body).to.be.a('object')
-        expect(res.body).to.have.property('id')
+      expect(res).to.have.status(OK)
+      expect(res.body).to.be.a('object')
+      expect(res.body).to.have.property('id')
     })
   })
 })

--- a/test/reactions/db-api/reaction-instance.js
+++ b/test/reactions/db-api/reaction-instance.js
@@ -16,7 +16,7 @@ const reactionInstance = require('../../../reactions/db-api/reaction-instance')
 const sampleReactionInstance = {
   reactionId: sampleReactionRule._id,
   resourceType: 'Article',
-  resourceId: '000001',
+  resourceId: ObjectId('abc123abc123'),
   results: []
 }
 
@@ -118,6 +118,48 @@ describe('db-api.reactionInstance', function () {
           ReactionInstanceMock.verify()
           ReactionInstanceMock.restore()
           sinon.assert.calledOnce(remove)
+        })
+    })
+  })
+
+  describe('#listResultsByPost', function () {
+    it('should list all the reactions instances ', function () {
+      const ReactionInstanceMock = sinon.mock(ReactionInstance)
+
+      ReactionInstanceMock
+        .expects('find').withArgs({ resourceId: ObjectId('abc123abc123') })
+        .chain('populate', { path: 'results', populate: { path: 'userId', select: 'name _id' } })
+        .chain('populate', 'reactionId')
+        .resolves(sampleReactionInstance)
+
+      return reactionInstance.listResultsByPost(ObjectId('abc123abc123'))
+        .then((result) => {
+          ReactionInstanceMock.verify()
+          ReactionInstanceMock.restore()
+          assert.equal(result, sampleReactionInstance)
+        })
+    })
+  })
+
+  describe('#getResult', function () {
+    it('should get the result of a reaction instance', function () {
+      const ReactionInstanceMock = sinon.mock(ReactionInstance)
+
+      ReactionInstanceMock
+        .expects('findOne')
+        .withArgs({ _id: ObjectId('5a5e29d948a9cc2fbeed02fa') })
+        .chain('populate', { path: 'results', populate: { path: 'userId', select: 'name _id' } })
+        .chain('populate', 'reactionId')
+        .chain('exec')
+        .resolves(sampleReactionInstance)
+
+      return reactionInstance.getResult(ObjectId('5a5e29d948a9cc2fbeed02fa'))
+        .then((result) => {
+          console.log(result)
+          console.log(sampleReactionInstance)
+          ReactionInstanceMock.verify()
+          ReactionInstanceMock.restore()
+          assert.equal(result, sampleReactionInstance)
         })
     })
   })

--- a/test/services/reactions.js
+++ b/test/services/reactions.js
@@ -1,0 +1,195 @@
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+const {
+  OK,
+  CREATED,
+  NO_CONTENT
+} = require('http-status')
+
+const ObjectID = require('mongodb').ObjectID
+
+const User = require('../../users/models/user')
+const sampleUsers = [
+  {
+    username: 'Jonhco',
+    name: 'Jonh Cork',
+    bio: 'test bio',
+    email: 'jonh@te.st'
+  },
+  {
+    username: 'JennyT',
+    name: 'Jenny Terry',
+    bio: 'test bio',
+    email: 'jennyt@te.st'
+  },
+  {
+    username: 'Markovz',
+    name: 'Mar Kovic',
+    bio: 'test bio',
+    email: 'marjovz@te.st'
+  },
+  {
+    username: 'maripet',
+    name: 'Peter Mari',
+    bio: 'test bio',
+    email: 'maripet@te.st'
+  }
+]
+
+const ReactionVote = require('../../reactions/models/reaction-vote')
+
+const ReactionRule = require('../../reactions/models/reaction-rule')
+
+const ReactionInstance = require('../../reactions/models/reaction-instance')
+
+const expect = chai.expect
+chai.use(chaiHttp)
+
+let users = []
+let votes = []
+let reactionRules = []
+let reactionInstances = []
+const resourceId = 'abc123abc123'
+let fakeResourceId = ObjectID(resourceId)
+
+describe('/api/v1.0/services/reactions', () => {
+  before(async () => {
+    await require('../../main')
+  })
+
+  beforeEach(async () => {
+    users = []
+    votes = []
+    reactionRules = []
+    reactionInstances = []
+    // Clean db
+    await ReactionInstance.remove({})
+    await ReactionRule.remove({})
+    await ReactionVote.remove({})
+    await User.remove({})
+    // Populate DB
+    users[0] = await (new User(sampleUsers[0])).save()
+    users[1] = await (new User(sampleUsers[1])).save()
+    users[2] = await (new User(sampleUsers[2])).save()
+    users[3] = await (new User(sampleUsers[3])).save()
+    votes[0] = await (new ReactionVote({
+      userId: users[0]._id,
+      value: 'LIKE'
+    })).save()
+    votes[1] = await (new ReactionVote({
+      userId: users[1]._id,
+      value: 'LIKE'
+    })).save()
+    votes[2] = await (new ReactionVote({
+      userId: users[2]._id,
+      value: 'LIKE'
+    })).save()
+    votes[3] = await (new ReactionVote({
+      userId: users[3]._id,
+      value: 'LIKE'
+    })).save()
+    votes[4] = await (new ReactionVote({
+      userId: users[0]._id,
+      value: 'LIKE'
+    })).save()
+    votes[5] = await (new ReactionVote({
+      userId: users[1]._id,
+      value: 'LIKE'
+    })).save()
+    reactionRules[0] = await (new ReactionRule({
+      method: 'LIKE',
+      name: 'Audition',
+      limit: '5',
+      startingDate: new Date('2017-12-20 00:00:00'),
+      closingDate: new Date('2018-02-20 00:00:00')
+    })).save()
+    reactionRules[1] = await (new ReactionRule({
+      method: 'LIKE',
+      name: 'Congress',
+      limit: '2',
+      startingDate: new Date('2017-12-20 00:00:00'),
+      closingDate: new Date('2018-02-20 00:00:00')
+    })).save()
+    reactionInstances[0] = await (new ReactionInstance({
+      reactionId: reactionRules[0]._id,
+      resourceType: 'Content',
+      resourceId: fakeResourceId,
+      results: [
+        votes[0]._id,
+        votes[1]._id,
+        votes[2]._id,
+        votes[3]._id
+      ]
+    })).save()
+    reactionInstances[1] = await (new ReactionInstance({
+      reactionId: reactionRules[1]._id,
+      resourceType: 'Content',
+      resourceId: fakeResourceId,
+      results: [
+        votes[4]._id,
+        votes[5]._id
+      ]
+    })).save()
+  })
+
+  describe('#list', () => {
+    it('should list all the results from all the reaction instances (2) of a post', async () => {
+
+      const res = await chai.request('http://localhost:3000')
+        .get('/api/v1.0/services/reactions/posts/' + resourceId + '/results')
+        .query()
+
+      expect(res).to.have.status(OK)
+
+      const results = res.body
+
+      expect(results).to.be.a('array')
+      expect(results.length).to.be.eql(2)
+      results.forEach((result) => {
+        expect(result).to.be.an('object')
+        expect(result).to.have.property('id')
+        expect(result).to.have.property('reactionRule')
+        expect(result).to.have.property('data')
+        expect(result).to.have.property('participants')
+        expect(result.participants).to.be.a('array')
+        expect(result.participants.length).to.be.at.least(2)
+        expect(result.participants[0]).to.have.property('_id')
+        expect(result.participants[0]).to.have.property('name')
+        expect(result.data).to.be.an('object')
+        expect(result.data).to.have.property('name')
+        expect(result.data.name).to.be.eql('LIKE')
+        expect(result.data).to.have.property('value')
+        expect(result.data.value).to.be.at.least(2)
+      })
+    })
+  })
+
+  describe('#getResult', () => {
+    it('should get the results from a reaction instances', async () => {
+
+      const res = await chai.request('http://localhost:3000')
+        .get('/api/v1.0/services/reactions/' + reactionInstances[0]._id + '/result')
+        .query()
+
+      expect(res).to.have.status(OK)
+
+      const result = res.body
+
+      // Expects for a result
+      expect(result).to.be.an('object')
+      expect(result).to.have.property('id')
+      expect(result).to.have.property('reactionRule')
+      expect(result).to.have.property('data')
+      expect(result).to.have.property('participants')
+      expect(result.participants).to.be.a('array')
+      expect(result.participants.length).to.be.eql(4)
+      expect(result.participants[0]).to.have.property('_id')
+      expect(result.participants[0]).to.have.property('name')
+      expect(result.data).to.be.an('object')
+      expect(result.data).to.have.property('name')
+      expect(result.data.name).to.be.eql('LIKE')
+      expect(result.data).to.have.property('value')
+      expect(result.data.value).to.be.eql(4)
+    })
+  })
+})


### PR DESCRIPTION
Finally! Added the so waited features needed for reactions feed

The objective was:
The reactions feed should show post cards, with title, summary and reactions count.
When clicked it should show a list of all users that reacted to it.
When a user row is clicked it should navigate to that resource in users admin.

For that we needed an API Service to give us the results. There are 2 types of queries:
- Get the result of a reaction instance
- Get the results for a post (Lets remember, there is no reference from a content -> reaction instance, and besides, this returns an ARRAY of results, cause a content might have more than one reaction instances)

This was needed cause for future uses we will need it to make post cards, not only for the admin panel but also for the webpage.

I made a component in the "Show reaction instance" of the admin panel.
If you want to test it you need to create a reaction instance combining a rule and a post.
Then create in the DB the reaction-votes (value in this case has no meaning, you can put whatever you want)
Create as many reaction-vote you want and then in the reaction instance add the array of objectIDs of the reaction-votes.

If you dont want that, have faith on my tests results!
I added tests for the service and for the changes in the db-api.

This closes #1551 and #1538