### PR TITLE
[v3] Add csrf key to all fetchs

### DIFF
--- a/client/admin/components/rest-client.js
+++ b/client/admin/components/rest-client.js
@@ -128,7 +128,6 @@ export default (type, resource, params) => {
   const { fetchJson } = fetchUtils
   const { url, options } = convertRESTRequestToHTTP(type, resource, params)
   options.credentials = 'include'
-  console.log(options.body)
   return fetchJson(url, options)
     .then((response) => convertHTTPResponseToREST(response, type, resource, params))
 }

--- a/client/admin/components/rest-client.js
+++ b/client/admin/components/rest-client.js
@@ -45,16 +45,22 @@ const convertRESTRequestToHTTP = (type, resource, params) => {
     case UPDATE:
       url = `${API_URL}/${resource}/${params.id}`
       options.method = 'PUT'
-      options.body = JSON.stringify(params.data)
+      options.body = params.data
+      options.body['_csrf'] = JSON.parse(localStorage.getItem('session')).csrfToken
+      options.body = JSON.stringify(options.body)
       break
     case CREATE:
       url = `${API_URL}/${resource}`
       options.method = 'POST'
-      options.body = JSON.stringify(params.data)
+      options.body = params.data
+      options.body['_csrf'] = JSON.parse(localStorage.getItem('session')).csrfToken
+      options.body = JSON.stringify(options.body)
       break
     case DELETE:
       url = `${API_URL}/${resource}/${params.id}`
       options.method = 'DELETE'
+      options.body['_csrf'] = JSON.parse(localStorage.getItem('session')).csrfToken
+      options.body = JSON.stringify(options.body)
       break
     case GET_MANY:
       const query = {
@@ -121,10 +127,8 @@ const convertHTTPResponseToREST = (response, type, resource, params) => {
 export default (type, resource, params) => {
   const { fetchJson } = fetchUtils
   const { url, options } = convertRESTRequestToHTTP(type, resource, params)
-  options.credentials = 'same-origin'
-  const body = JSON.parse(options.body)
-  body['_csrf'] = JSON.parse(localStorage.getItem('session')).csrfToken
-  options.body = JSON.stringify(body)
+  options.credentials = 'include'
+  console.log(options.body)
   return fetchJson(url, options)
     .then((response) => convertHTTPResponseToREST(response, type, resource, params))
 }

--- a/client/admin/components/rest-client.js
+++ b/client/admin/components/rest-client.js
@@ -121,6 +121,10 @@ const convertHTTPResponseToREST = (response, type, resource, params) => {
 export default (type, resource, params) => {
   const { fetchJson } = fetchUtils
   const { url, options } = convertRESTRequestToHTTP(type, resource, params)
+  options.credentials = 'same-origin'
+  const body = JSON.parse(options.body)
+  body['_csrf'] = JSON.parse(localStorage.getItem('session')).csrfToken
+  options.body = JSON.stringify(body)
   return fetchJson(url, options)
     .then((response) => convertHTTPResponseToREST(response, type, resource, params))
 }

--- a/client/site/components/page.js
+++ b/client/site/components/page.js
@@ -6,8 +6,7 @@ export default class extends React.Component {
     const baseUrl = req ? `${req.protocol}://${req.get('Host')}` : ''
     return {
       session: await NextAuth.init({ req }),
-      settings: await (await fetch(baseUrl + '/api/v1.0/settings', {
-        credentials: 'include' })).json()
+      settings: await (await fetch(baseUrl + '/api/v1.0/settings')).json()
     }
   }
 }

--- a/client/site/components/post-grid.js
+++ b/client/site/components/post-grid.js
@@ -13,9 +13,7 @@ export default class PostGrid extends React.Component {
 
   componentDidMount () {
     window.addEventListener('scroll', this.onScroll, false)
-    fetch(`/api/v1.0/posts?page=${this.state.page}`, {
-      'credentials': 'include'
-    })
+    fetch(`/api/v1.0/posts?page=${this.state.page}`)
       .then((res) => res.json())
       .then((res) => {
         this.setState({
@@ -42,9 +40,7 @@ export default class PostGrid extends React.Component {
   handlePagination = () => {
     const nextPage = this.state.page + 1
     const url = `/api/v1.0/posts?page=${nextPage}`
-    fetch(url, {
-      credentials: 'include'
-    })
+    fetch(url)
       .then((res) => res.json())
       .then((res) => {
         this.setState({

--- a/client/site/components/profile/private-profile.js
+++ b/client/site/components/profile/private-profile.js
@@ -32,15 +32,20 @@ export class PrivateProfile extends React.Component {
   handleSubmit = (e) => {
     e.preventDefault()
     const url = `/api/v1.0/users/${this.props.user._id}`
+    const session = JSON.parse(localStorage.getItem('session'))
+    console.log(session)
+    const csrf = session.csrfToken
     const body = {
       bio: this.state.bio,
       name: this.state.name,
-      username: this.state.username
+      username: this.state.username,
+      _csrf: csrf
     }
     fetch(url, {
       'headers': {
         'Content-Type': 'application/json'
       },
+      credentials: 'include',
       method: 'PUT',
       body: JSON.stringify(body)
     })

--- a/client/site/components/profile/private-profile.js
+++ b/client/site/components/profile/private-profile.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { fetchWrapper } from '../../../utils/fetch-wrapper'
 
 export class PrivateProfile extends React.Component {
   constructor (props) {
@@ -29,37 +30,28 @@ export class PrivateProfile extends React.Component {
     })
   }
 
-  handleSubmit = (e) => {
+  handleSubmit = async (e) => {
     e.preventDefault()
     const url = `/api/v1.0/users/${this.props.user._id}`
-    const session = JSON.parse(localStorage.getItem('session'))
-    console.log(session)
-    const csrf = session.csrfToken
-    const body = {
-      bio: this.state.bio,
-      name: this.state.name,
-      username: this.state.username,
-      _csrf: csrf
-    }
-    fetch(url, {
-      'headers': {
-        'Content-Type': 'application/json'
-      },
+    const options = {
+      'headers': { 'Content-Type': 'application/json' },
       credentials: 'include',
       method: 'PUT',
-      body: JSON.stringify(body)
-    })
-      .then((res) => res.json())
-      .then((res) => {
-        this.setState({ success: true })
-        setTimeout(() => this.setState({
-          success: false
-        }), 5000)
-      })
-      .catch((err) => {
-        console.error(err)
-        this.setState({ error: true })
-      })
+      body: {
+        bio: this.state.bio,
+        name: this.state.name,
+        username: this.state.username
+      }
+    }
+    try {
+      fetchWrapper(url, options)
+      this.setState({ success: true })
+      setTimeout(() => this.setState({
+        success: false
+      }), 5000)
+    } catch (error) {
+      this.setState({ error: true }, () => console.error(err))
+    }
   }
 
   render () {

--- a/client/site/components/reactions/vote-like-reaction.js
+++ b/client/site/components/reactions/vote-like-reaction.js
@@ -2,6 +2,8 @@ import React from 'react'
 import Results from './results-like-reaction'
 import PleaseLogInModal from './please-login-modal'
 import VotingClosedModal from './voting-closed-modal'
+import { fetchWrapper } from '../../../utils/fetch-wrapper'
+
 
 export default class extends React.Component {
   constructor (props) {
@@ -34,17 +36,17 @@ export default class extends React.Component {
         pleaseLogIn: true
       })
     } else {
-      const body = {
-        userId: this.props.user.id,
-      }
       // No. Then lets create his firt vote
-      let response = await (await fetch(`/api/v1.0/services/reactions/${this.state.reaction.id}/vote`, {
-        'body': JSON.stringify(body),
-        'method': 'POST',
-        'headers': {
-          'Content-Type': 'application/json'
+      const url = `/api/v1.0/services/reactions/${this.state.reaction.id}/vote`
+      const options = {
+        'headers': { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        method: 'POST',
+        body: {
+          userId: this.props.user.id,
         }
-      })).json()
+      }
+      let response = await (await fetchWrapper(url, options)).json()
       let updatedReaction = await (await fetch(`/api/v1.0/services/reactions/${this.state.reaction.id}/result`)).json()
       this.setState({
         myVote: response,

--- a/client/site/components/register/register-form.js
+++ b/client/site/components/register/register-form.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
+import { fetchWrapper } from '../../../utils/fetch-wrapper'
 
 export default class RegisterForm extends React.Component {
   constructor (props) {
@@ -19,28 +20,27 @@ export default class RegisterForm extends React.Component {
     this.setState({ [name]: value })
   }
 
-  handleSubmit = (e) => {
+  handleSubmit = async (e) => {
     e.preventDefault()
-    const body = {
-      firstLogin: false,
-      username: this.state.username,
-      bio: this.state.bio,
-      name: this.state.name
-    }
-    fetch(`/api/v1.0/users/${this.props.id}`, {
+    const url = `/api/v1.0/users/${this.props.id}`
+    const options = {
       'method': 'PUT',
       'headers': {
         'Content-Type': 'application/json'
       },
-      'body': JSON.stringify(body)
-    })
-      .then((res) => res.json())
-      .then((res) => {
-        this.props.role === 'admin' ? Router.push('/init-settings') : Router.push('/')
-      })
-      .catch((err) => {
-        this.setState({ error: true }, () => console.err(err))
-      })
+      'body': {
+        firstLogin: false,
+        username: this.state.username,
+        bio: this.state.bio,
+        name: this.state.name
+      }
+    }
+    try {
+      await fetchWrapper(url, options)
+      this.props.role === 'admin' ? Router.push('/init-settings') : Router.push('/')
+    } catch (error) {
+      this.setState({ error: true }, () => console.error(error))
+    }
   }
 
   render () {

--- a/client/site/components/settings/settings-form.js
+++ b/client/site/components/settings/settings-form.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { fetchWrapper } from '../../../utils/fetch-wrapper'
 import SettingsModal from './settings-modal'
 
 export default class SettingsForm extends React.Component {
@@ -12,30 +13,25 @@ export default class SettingsForm extends React.Component {
     }
   }
 
-  handleSubmit = (e) => {
+  handleSubmit = async (e) => {
     e.preventDefault()
-    fetch('/api/v1.0/settings', {
+    const url = '/api/v1.0/settings'
+    const options = {
       'method': 'POST',
       'headers': {
         'Content-Type': 'application/json'
       },
-      'body': JSON.stringify({
+      'body': {
         'communityName': this.state.communityName,
         'mainColor': this.state.mainColor
-      })
-    })
-      .then((res) => res.json())
-      .then((res) => {
-        this.setState({
-          success: true
-        })
-      })
-      .catch((err) => {
-        console.log(err)
-        this.setState({
-          error: true
-        })
-      })
+      }
+    }
+    try {
+      await fetchWrapper(url, options)
+      this.setState({ success: true })
+    } catch (error) {
+      this.setState({ error: true }, () => console.error(error))
+    }
   }
 
   handleChange = (e) => {

--- a/client/utils/fetch-wrapper.js
+++ b/client/utils/fetch-wrapper.js
@@ -1,0 +1,14 @@
+const fetchWrapper = (url, options) => {
+  // Add credentials
+  options.credentials = 'include'
+  // If the method affects the content in the DB add the csrf token
+  if (options.method === 'POST' || options.method === 'PUT' || options.method === 'DELETE') {
+    options.body['_csrf'] = JSON.parse(localStorage.getItem('session')).csrfToken
+    options.body = JSON.stringify(options.body)
+  }
+
+  // Do the fetch and return the response or the error msg
+  return fetch(url, options)
+}
+
+module.exports = { fetchWrapper }

--- a/cms/api/settings.js
+++ b/cms/api/settings.js
@@ -22,6 +22,7 @@ router.route('/')
     }
   })
   .get(async (req, res, next) => {
+    console.log(req.user)
     // returns Settings only record
     try {
       const results = await Setting.getOne()

--- a/cms/components/admin.js
+++ b/cms/components/admin.js
@@ -16,7 +16,7 @@ import Navbar from './navbar'
 const history = createHistory({ basename: '/admin' })
 
 export default (props) => (
-  <Admin title='Democracy OS' restClient={RestClient} customRoutes={CustomRoutes} history={history} dashboard={Dashboard} menu={Navbar} >
+  <Admin title='Democracy OS' restClient={RestClient} customRoutes={CustomRoutes} history={history} dashboard={Dashboard} menu={Navbar}  >
     <Resource name='posts' list={PostList} show={PostShow} create={PostCreate} edit={PostEdit} remove={Delete} />
     <Resource name='reaction-rule' options={{ label: 'Reaction Rules' }} list={ReactionRuleList} create={ReactionRuleCreate} edit={ReactionRuleEdit} />
     <Resource name='reaction-instance' options={{ label: 'Reaction Instances' }} show={ReactionInstanceShow} list={ReactionInstanceList} create={ReactionInstanceCreate} edit={ReactionInstanceEdit} />

--- a/main/index.js
+++ b/main/index.js
@@ -31,8 +31,8 @@ module.exports = (async () => {
     server.use(compression())
     server.use(express.json())
     server.use(express.urlencoded({ extended: true }))
-    // server.use(passport.initialize())
-    // server.use(passport.session())
+    server.use(passport.initialize())
+    server.use(passport.session())
     // server.use(loggerMiddleware)
     server.use(i18nMiddleware)
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -30,7 +30,6 @@ export default class extends Page {
   render () {
     return (
       <div className='container'>
-        {console.log(this.props)}
         <Head {...this.props} />
         <Header settings={this.props.settings} user={this.props.session.user} />
         <div className='text-center'>

--- a/pages/index.js
+++ b/pages/index.js
@@ -30,6 +30,7 @@ export default class extends Page {
   render () {
     return (
       <div className='container'>
+        {console.log(this.props)}
         <Head {...this.props} />
         <Header settings={this.props.settings} user={this.props.session.user} />
         <div className='text-center'>

--- a/pages/post.js
+++ b/pages/post.js
@@ -14,7 +14,7 @@ export default class extends Page {
 
   async componentDidMount () {
     const post = await (await fetch(`/api/v1.0/posts/${this.props.url.query.id}`)).json()
-    this.setState({post: post})
+    this.setState({ post })
   }
 
   render () {

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -22,9 +22,7 @@ export default class extends Page {
   }
 
   async componentDidMount () {
-    fetch(`/api/v1.0/users/${this.props.id}`, {
-      credentials: 'include'
-    })
+    fetch(`/api/v1.0/users/${this.props.id}`)
       .then((res) => res.json())
       .then((res) => {
         this.setState({ user: res })


### PR DESCRIPTION
This PR adds

- Crsf key in rest client of all POST/PUT/DELETE requests
- A fetch wrapper (located at `client/utils/fetch-wrapper`) to add csrf key and credentials to all the fetchs that need it. 
You must import fetchWrapper and then pass it an url and an options object (header and body included). It will return a response or error object.
Please check with care 🌈