### PR TITLE
[v3] Fix for voting a reaction

### DIFF
--- a/client/admin/components/rest-client.js
+++ b/client/admin/components/rest-client.js
@@ -59,7 +59,9 @@ const convertRESTRequestToHTTP = (type, resource, params) => {
     case DELETE:
       url = `${API_URL}/${resource}/${params.id}`
       options.method = 'DELETE'
-      options.body['_csrf'] = JSON.parse(localStorage.getItem('session')).csrfToken
+      options.body = {
+        '_csrf': JSON.parse(localStorage.getItem('session')).csrfToken
+      }
       options.body = JSON.stringify(options.body)
       break
     case GET_MANY:

--- a/client/site/components/reactions/please-login-modal.js
+++ b/client/site/components/reactions/please-login-modal.js
@@ -1,21 +1,25 @@
 import React from 'react'
 import Link from 'next/link'
 
-export default () => (
-  <div className='overlay'>
-    <div className='settings-modal text-center'>
-      <h5>Participate today! 🙌</h5>
-      <p>To save your action, we need you to be logged in!</p>
-      <Link href='/auth'>
-        <button className='btn btn-primary'>
-          Log in
-        </button>
-      </Link>
-      <button onClick={this.props.closeModal} className='btn btn-primary'>
-        Log in
-      </button>
-    </div>
-    <style jsx>{`
+export default class extends React.Component {
+  render () {
+    const props = this.props
+
+    return (
+      <div className='overlay'>
+        <div className='settings-modal text-center'>
+          <h5>Participate today! 🙌</h5>
+          <p>To save your action, we need you to be logged in!</p>
+          <Link href='/auth'>
+            <button className='btn btn-primary'>
+              Log in
+            </button>
+          </Link>
+          <button onClick={props.closeModal} className='btn btn-white'>
+            Go back
+          </button>
+        </div>
+        <style jsx>{`
       .overlay {
         position: fixed; 
         display: flex;
@@ -43,5 +47,7 @@ export default () => (
         box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
       }
     `}</style>
-  </div>
-)
+      </div>
+    )
+  }
+}

--- a/client/site/components/reactions/vote-like-reaction.js
+++ b/client/site/components/reactions/vote-like-reaction.js
@@ -1,9 +1,8 @@
 import React from 'react'
+import { fetchWrapper } from '../../../utils/fetch-wrapper'
 import Results from './results-like-reaction'
 import PleaseLogInModal from './please-login-modal'
 import VotingClosedModal from './voting-closed-modal'
-import { fetchWrapper } from '../../../utils/fetch-wrapper'
-
 
 export default class extends React.Component {
   constructor (props) {
@@ -20,18 +19,18 @@ export default class extends React.Component {
   }
 
   async componentWillMount () {
-    if (this.props.user != null) {
-      let vote = this.state.reaction.participants.find((x) => { return x.userId._id == this.props.user.id })
+    if (this.props.user !== undefined) {
+      let vote = this.state.reaction.participants.find((x) => { return x.userId._id === this.props.user.id })
       if (vote !== undefined) {
         this.setState({ myVote: vote })
       }
     } else {
-      this.setState({ myVote: false })
+      this.setState({ myVote: {} })
     }
   }
 
   voteAction = async () => {
-    if (this.props.user == null) {
+    if (this.props.user === undefined) {
       this.setState({
         pleaseLogIn: true
       })
@@ -42,9 +41,7 @@ export default class extends React.Component {
         'headers': { 'Content-Type': 'application/json' },
         credentials: 'include',
         method: 'POST',
-        body: {
-          userId: this.props.user.id,
-        }
+        body: {}
       }
       let response = await (await fetchWrapper(url, options)).json()
       let updatedReaction = await (await fetch(`/api/v1.0/services/reactions/${this.state.reaction.id}/result`)).json()
@@ -104,7 +101,7 @@ export default class extends React.Component {
     this.setState({ voteClosed: false })
   }
 
-  closeModalPleaseLogIn = (e) =>{
+  closeModalPleaseLogIn = (e) => {
     this.setState({ pleaseLogIn: false })
   }
 

--- a/client/site/components/reactions/voting-closed-modal.js
+++ b/client/site/components/reactions/voting-closed-modal.js
@@ -8,9 +8,9 @@ export default class extends React.Component {
     return (
       <div className='overlay'>
         <div className='settings-modal text-center'>
-          <h5>The voting has closed! ⛔</h5>
-          <button onClick={props.closeModal} className='btn btn-primary'>
-              Close
+          <h5>The voting for this reaction is closed! ⛔</h5>
+          <button onClick={props.closeModal} className='btn btn-white'>
+              Go back
           </button>
         </div>
         <style jsx>{`


### PR DESCRIPTION
This fix was bound to happen after the merged pull request for authentication.

So basically voting a reaction doesn't need you to tell the API who you are (cause that is not your business, dear user). The server will know if you are a logged user and if not, you will get a FORBIDDEN message.

Any test is appreciated c:
Chiirs!   